### PR TITLE
chore: migrating to unreliable datagrams instead of ordered streams

### DIFF
--- a/client/src-tauri/src/audio/stream/stream_manager/output.rs
+++ b/client/src-tauri/src/audio/stream/stream_manager/output.rs
@@ -459,7 +459,7 @@ impl OutputStream {
                         owner: owner.clone(),
                         buffer: SamplesBuffer::<f32>::new(
                             2, // is this _always_ a mono channel? Shouldn't this be stero sometimes too?
-                            data.sample_rate,
+                            data.sample_rate.into(),
                             out
                         ),
                         coordinate: data.coordinate,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,7 +22,7 @@ pub enum Dimension {
     Overworld,
     #[serde(rename = "the_end")]
     TheEnd,
-    #[serde(rename = "the_nether")]
+    #[serde(rename = "nether")]
     TheNether,
 }
 

--- a/common/src/structs/packet.rs
+++ b/common/src/structs/packet.rs
@@ -393,11 +393,35 @@ impl TryFrom<QuicNetworkPacketData> for CollectionPacket {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum SampleRate {
+    Hz48000
+}
+
+impl From<SampleRate> for u32 {
+    fn from(sr: SampleRate) -> u32 {
+        match sr {
+            SampleRate::Hz48000 => 48000,
+        }
+    }
+}
+
+impl TryFrom<u32> for SampleRate {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            48000 => Ok(SampleRate::Hz48000),
+            _ => Err(()),
+        }
+    }
+}
+
 /// A single, Opus encoded audio frame
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AudioFramePacket {
-    pub length: usize,
-    pub sample_rate: u32,
+    pub frame_counter: u32,
+    pub sample_rate: SampleRate,
     pub data: Vec<u8>,
     pub coordinate: Option<Coordinate>,
     pub orientation: Option<Orientation>,


### PR DESCRIPTION
Experimenting with QUIC Datagrams.

https://github.com/aws/s2n-quic/blob/main/examples/unreliable-datagram/src/bin/datagram_sender.rs

Datagrams are standard, but are unreliable, however we get guaranteed packet construction on the receiver. This will require both client and server modifications to consume.