### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,4 +1,6 @@
 name: Build Android Client
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/4](https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/4)

To fix this problem, add an explicit `permissions` block with minimal required access at the workflow (root) level or within the relevant job(s). The most direct approach is to add the block at the workflow root, which will apply to all jobs unless a job-specific block is defined. For this workflow, set `contents: read`, signifying that only read access to repository contents is required. No write permissions to issues, pull requests, or other repository resources are necessary. The change should be placed directly after the `name` field and before the `on:` block at the top of `.github/workflows/build-android.yml`. No additional imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
