### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,4 +1,6 @@
 name: Build Windows Client
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/3](https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/3)

To fix the problem, we should add an explicit `permissions` block to the workflow. Because this workflow builds and uploads artifacts but does not push code, modify issues, or do anything requiring write access to repository contents, the minimal permissions requirement is `contents: read`. This can be set at the root of the workflow, applying to all jobs, by adding the block right after the `name:` and before `on:`. No other write permissions appear needed from the contents of the workflow. No additional methods or dependencies are needed to implement this; it's purely a configuration fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
