### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -28,6 +28,8 @@ on:
           - debug
           - release
 
+permissions:
+  contents: read
 jobs:
   build-server:
     name: Build Server (${{ matrix.target }} - ${{ github.event_name == 'pull_request' && 'debug' || inputs.build_mode || 'debug' }})


### PR DESCRIPTION
Potential fix for [https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/2](https://github.com/Alaydriem/bedrock-voice-chat/security/code-scanning/2)

The best way to fix this problem is to explicitly set the least required permissions for the job or entire workflow using a `permissions:` block, so that the GITHUB_TOKEN is granted only the required access. In your workflow, the necessary permission is `contents: read`, which allows checking out the repository but does not grant write access to code, issues, etc. To implement this fix, add:

```yaml
permissions:
  contents: read
```

either at the root level (before `jobs:`), or inside the `build-server:` job if only that job requires it (the root level is preferable for clarity and future extensibility). You do not need to add more granular permissions as there are no steps requiring write access to issues, pull requests, etc.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
