### PR TITLE
refactor: cpal 17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "alsa-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +602,7 @@ dependencies = [
  "bytes",
  "chrono",
  "common",
- "cpal",
+ "cpal 0.17.0",
  "flume 0.12.0",
  "futures-util",
  "log",
@@ -1388,14 +1400,13 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
- "alsa",
- "asio-sys",
+ "alsa 0.9.1",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.4.3",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -1407,6 +1418,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ceb96745bc9bbcf1f7eb1267ee03045275fa0cc82a4b34d8534ffdcaf657c3"
+dependencies = [
+ "alsa 0.10.0",
+ "asio-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2 0.5.0",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3853,6 +3895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4396,6 +4447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,6 +4477,7 @@ dependencies = [
  "objc2",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4446,7 +4508,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -5961,7 +6025,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40ecf59e742e03336be6a3d53755e789fd05a059fa22dfa0ed624722319e183"
 dependencies = [
- "cpal",
+ "cpal 0.16.0",
  "dasp_sample",
  "num-rational",
  "symphonia",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -80,10 +80,10 @@ tauri-plugin-process = "^2.3"
 
 [target."cfg(any(target_os = \"windows\"))".dependencies]
 windows-targets = "^0.53.0"
-cpal = { version = "^0.16", features = ["asio", "asio-sys"] }
+cpal = { version = "^0.17", features = ["asio"] }
 
 [target."cfg(any(target_os = \"android\", target_os = \"ios\"))".dependencies]
-cpal = { version = "^0.16" }
+cpal = { version = "^0.17" }
 
 [dev-dependencies]
 

--- a/client/src-tauri/src/audio/tests.rs
+++ b/client/src-tauri/src/audio/tests.rs
@@ -62,13 +62,9 @@ fn get_devices() {
         match host.input_devices() {
             Ok(devices) => {
                 for device in devices {
-                    let name = match device.name() {
-                        Ok(name) => name,
-                        Err(e) => {
-                            println!("{}", e.to_string());
-                            continue;
-                        }
-                    };
+                    let name = device.description().unwrap_or_else(|| {
+                        device.id().unwrap_or_else(|_| "unknown".to_string())
+                    });
 
                     println!("[{}] {}", host.id().name(), name);
                 }


### PR DESCRIPTION
Migrates application to use CPAL 17, which now supports sync + send on streams

This requires Rodio to be updated to take advantage of CPAL 17, which may take a while. The current PR state handles the input side. Once Rodio is updated we can bump the version there and it should pass tests.

[Upgrading Guide](https://github.com/RustAudio/cpal/blob/v0.17.0/UPGRADING.md)
[Changelog](https://github.com/RustAudio/cpal/blob/v0.17.0/CHANGELOG.md)