### PR TITLE
fix: audio playback issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "ts-rs",

--- a/client/src-tauri/src/audio/stream/stream_manager/output.rs
+++ b/client/src-tauri/src/audio/stream/stream_manager/output.rs
@@ -687,4 +687,12 @@ impl OutputStream {
     pub fn mute_status(&self) -> bool {
         MUTE_OUTPUT_STREAM.load(Ordering::Relaxed)
     }
+
+    /// Returns the list of currently tracked players from the presence cache
+    pub fn get_current_players(&self) -> Vec<String> {
+        self.player_presence
+            .iter()
+            .map(|(name, _)| (*name).clone())
+            .collect()
+    }
 }

--- a/client/src-tauri/src/commands/network.rs
+++ b/client/src-tauri/src/commands/network.rs
@@ -97,22 +97,9 @@ pub(crate) async fn change_network_stream(
 
 #[tauri::command]
 pub(crate) async fn reset_nsm(
-    handle: AppHandle,
     nsm: State<'_, Mutex<NetworkStreamManager>>,
 ) -> Result<(), ()> {
     let mut nsm = nsm.lock().await;
-    _ = nsm.stop().await;
-
-    _ = tokio::time::sleep(Duration::from_millis(100)).await;
-
-    handle.manage(Mutex::new(NetworkStreamManager::new(
-        handle.state::<Arc<Sender<AudioPacket>>>().inner().clone(),
-        handle
-            .state::<Arc<Receiver<NetworkPacket>>>()
-            .inner()
-            .clone(),
-        handle.clone(),
-    )));
-
+    _ = nsm.reset().await;
     Ok(())
 }

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ pub fn run() {
             crate::commands::audio::stop_recording,
             crate::commands::audio::get_recording_status,
             crate::commands::audio::is_recording,
+            crate::commands::audio::get_current_players,
             // Recordings Management
             crate::commands::recordings::get_recording_sessions,
             crate::commands::recordings::delete_recording_session,

--- a/client/src-tauri/src/network/stream/mod.rs
+++ b/client/src-tauri/src/network/stream/mod.rs
@@ -113,4 +113,29 @@ impl NetworkStreamManager {
 
         Ok(())
     }
+
+    /// Resets the network stream manager by stopping all streams and recreating them
+    pub async fn reset(&mut self) -> Result<(), anyhow::Error> {
+        // Stop both streams concurrently
+        let (_, _) = tokio::join!(
+            self.input.stop(),
+            self.output.stop()
+        );
+
+        // Recreate streams without connection (will be reconnected later)
+        self.input = StreamTraitType::Input(stream_manager::InputStream::new(
+            self.producer.clone(),
+            None,
+            self.app_handle.clone(),
+        ));
+
+        self.output = StreamTraitType::Output(stream_manager::OutputStream::new(
+            self.consumer.clone(),
+            None,
+            None,
+            self.app_handle.clone(),
+        ));
+
+        Ok(())
+    }
 }

--- a/client/src/js/app/dashboard.ts
+++ b/client/src/js/app/dashboard.ts
@@ -156,6 +156,11 @@ export default class Dashboard extends BVCApp {
                 // Initialize audio devices and network stream
                 await this.initializeAudioDevicesAndNetworkStream(this.store!, currentServer ?? "", this.currentServerCredentials);
 
+                // Re-initialize AudioActivityManager since shutdown() destroyed it
+                if (this.audioActivityManager) {
+                    await this.audioActivityManager.initialize();
+                }
+
                 // Update notification
                 await updateNotification({
                     title: "Bedrock Voice Chat",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -61,6 +61,7 @@ postcard = { version = "^1.1", features = [ "use-std", "postcard-derive" ] }
 residua-zigzag = { version = "^0.1", package = "residua-zigzag" }
 leb128 = { version = "^0.2" }
 serde_bytes = { version = "^0.11" }
+thiserror = { version = "^2" }
 
 # Optional: QUIC support
 s2n-quic = { version = "=1.71.0", default-features = false, features = [

--- a/common/src/errors/communication/generic.rs
+++ b/common/src/errors/communication/generic.rs
@@ -1,0 +1,7 @@
+//! Generic game communication errors
+
+/// Generic game communication errors
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum GenericCommunicationError {
+    // Placeholder for future generic game errors
+}

--- a/common/src/errors/communication/minecraft.rs
+++ b/common/src/errors/communication/minecraft.rs
@@ -1,0 +1,13 @@
+//! Minecraft-specific communication errors
+
+use crate::game_data::Dimension;
+
+/// Minecraft-specific communication errors
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum MinecraftCommunicationError {
+    #[error("dimension mismatch: sender={sender:?}, recipient={recipient:?}")]
+    DimensionMismatch {
+        sender: Dimension,
+        recipient: Dimension,
+    },
+}

--- a/common/src/errors/communication/mod.rs
+++ b/common/src/errors/communication/mod.rs
@@ -1,0 +1,50 @@
+//! Communication errors between players
+
+mod generic;
+mod minecraft;
+
+pub use generic::GenericCommunicationError;
+pub use minecraft::MinecraftCommunicationError;
+
+use crate::Game;
+
+/// Game-specific error wrapper
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum GameError {
+    #[error("minecraft: {0}")]
+    Minecraft(MinecraftCommunicationError),
+
+    #[error("generic: {0}")]
+    Generic(GenericCommunicationError),
+}
+
+/// Error returned when two players cannot communicate
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum CommunicationError {
+    /// Players are in different games (e.g., Minecraft vs Generic)
+    #[error("game mismatch: sender={sender_game:?}, recipient={recipient_game:?}")]
+    GameMismatch {
+        sender_game: Game,
+        recipient_game: Game,
+    },
+
+    /// Players are too far apart (common across all games)
+    #[error("out of range: distance={distance:.2}, max_range={max_range:.2}")]
+    OutOfRange { distance: f32, max_range: f32 },
+
+    /// Game-specific error
+    #[error("{0}")]
+    Game(GameError),
+}
+
+impl CommunicationError {
+    /// Convenience constructor for Minecraft errors
+    pub fn minecraft(err: MinecraftCommunicationError) -> Self {
+        CommunicationError::Game(GameError::Minecraft(err))
+    }
+
+    /// Convenience constructor for Generic game errors
+    pub fn generic(err: GenericCommunicationError) -> Self {
+        CommunicationError::Game(GameError::Generic(err))
+    }
+}

--- a/common/src/errors/mod.rs
+++ b/common/src/errors/mod.rs
@@ -1,0 +1,7 @@
+//! Error types for the common crate
+
+pub mod communication;
+
+pub use communication::{
+    CommunicationError, GameError, GenericCommunicationError, MinecraftCommunicationError,
+};

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ncryptflib;
 
 pub mod auth;
 pub mod encoding;
+pub mod errors;
 pub use serde::{Deserialize, Serialize};
 
 pub mod consts;
@@ -12,6 +13,9 @@ pub mod structs;
 pub mod traits;
 pub mod players;
 pub mod game_data;
+
+// Re-export error types
+pub use errors::{CommunicationError, GameError, MinecraftCommunicationError, GenericCommunicationError};
 
 // Re-export s2n-quic when feature is enabled
 #[cfg(feature = "quic")]

--- a/common/src/players/generic.rs
+++ b/common/src/players/generic.rs
@@ -1,5 +1,6 @@
-use crate::{Coordinate, Game, Orientation};
+use crate::errors::CommunicationError;
 use crate::traits::player_data::{PlayerData, SpatialPlayer};
+use crate::{Coordinate, Game, Orientation};
 use serde::{Deserialize, Serialize};
 
 /// Generic player implementation for games that don't need special spatial logic
@@ -38,7 +39,18 @@ impl PlayerData for GenericPlayer {
 impl SpatialPlayer for GenericPlayer {}
 
 impl GenericPlayer {
-    pub fn can_communicate_with(&self, other: &GenericPlayer, range: f32) -> bool {
-        self.distance_to(other) <= range
+    pub fn can_communicate_with(
+        &self,
+        other: &GenericPlayer,
+        range: f32,
+    ) -> Result<(), CommunicationError> {
+        let distance = self.distance_to(other);
+        if distance > range {
+            return Err(CommunicationError::OutOfRange {
+                distance,
+                max_range: range,
+            });
+        }
+        Ok(())
     }
 }

--- a/common/src/structs/packet.rs
+++ b/common/src/structs/packet.rs
@@ -253,7 +253,8 @@ impl QuicNetworkPacket {
 
                         // Use can_communicate_with() for spatial logic
                         if let (Some(sender), Some(recipient)) = (&actual_sender, &actual_recipient) {
-                            if !sender.can_communicate_with(recipient, range) {
+                            if let Err(e) = sender.can_communicate_with(recipient, range) {
+                                tracing::debug!("Audio packet rejected: {}", e);
                                 return false;
                             }
 
@@ -263,7 +264,7 @@ impl QuicNetworkPacket {
                                     self.data = QuicNetworkPacketData::AudioFrame(data);
                                     return true;
                                 }
-                                Some(false) => return false,  // Rejected: non-channel spatial=false not allowed
+                                Some(false) => return false,
                                 None => {
                                     data.spatial = Some(true);
                                     self.data = QuicNetworkPacketData::AudioFrame(data);
@@ -272,6 +273,7 @@ impl QuicNetworkPacket {
                             }
                         }
 
+                        tracing::debug!("Could not find position data for sender or recipient");
                         // Fallback: sender or recipient not in cache
                         // Only allow explicitly non-spatial audio (matches current behavior)
                         match data.spatial {

--- a/mods/bds/.gitignore
+++ b/mods/bds/.gitignore
@@ -1,3 +1,4 @@
 *.mcpack
 *.mcaddon
 node_modules/
+*.zip

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "ts-rs",


### PR DESCRIPTION
- Resolves an issue with audio playback that prevents players from hearing each other in certain circumstances
- Fixes an issue with the UI where player presence + speaking state would be lost on page transitions or engine reloads
- Fixes an issue where audio manager + network manager reset didn't actually reset the entire audio engine and network engine correctly with Tauri.
- Adds specific error types in debug!() mode for better diagnostics for when players cannot hear each other
- Fixes an issue where the player outline when a player is speaking wouldn't always appear