### PR TITLE
fix: workflow updates for the correct release version metadata

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: 'debug'
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       build_mode:
@@ -29,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -248,7 +254,7 @@ jobs:
           echo "Verifying copied icons:"
           find "$TARGET_RES" -name "ic_launcher*" -exec ls -la {} \;
 
-      - name: Build Android (debug)
+      - name: Build Android
         working-directory: ./client
         env:
           # libclang - keep using the system libclang 17

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: 'debug'
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       build_mode:
@@ -29,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-mod-bds.yml
+++ b/.github/workflows/build-mod-bds.yml
@@ -2,6 +2,11 @@ name: Build BDS Pack
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -15,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-mod-fabric.yml
+++ b/.github/workflows/build-mod-fabric.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to build (overrides gradle.properties)'
         required: false
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
     outputs:
       version:
         description: 'The version that was built'
@@ -36,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Download Windows x64 native library
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-mod-hytale.yml
+++ b/.github/workflows/build-mod-hytale.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to build (overrides gradle.properties)'
         required: false
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
     secrets:
       HYTALE_DOWNLOADER_CREDENTIALS:
         description: 'Hytale downloader credentials JSON'
@@ -40,6 +44,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Download Windows x64 native library
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-mod-paper.yml
+++ b/.github/workflows/build-mod-paper.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to build (overrides gradle.properties)'
         required: false
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
     outputs:
       version:
         description: 'The version that was built'
@@ -36,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Download Windows x64 native library
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: 'debug'
         type: string
+      ref:
+        description: 'Git ref to checkout (tag, branch, or SHA)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       build_mode:
@@ -54,6 +58,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-mod-java.yaml
+++ b/.github/workflows/release-mod-java.yaml
@@ -132,7 +132,6 @@ jobs:
           version: ${{ needs.prepare-release.outputs.new_release_version }}
           name: Bedrock Voice Chat ${{ needs.prepare-release.outputs.new_release_version }} (Fabric)
           changelog: ${{ needs.prepare-release.outputs.new_release_notes }}
-          featured: true
           dependencies: |-
             [{
               "project_id": "P7dR8mSH",
@@ -172,7 +171,6 @@ jobs:
           version: ${{ needs.prepare-release.outputs.new_release_version }}-paper
           name: Bedrock Voice Chat ${{ needs.prepare-release.outputs.new_release_version }} (Paper)
           changelog: ${{ needs.prepare-release.outputs.new_release_notes }}
-          featured: true
           loaders: |-
             paper
             spigot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
     uses: ./.github/workflows/build-server.yml
     with:
       build_mode: release
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 3: Build Android (release mode, includes signing)
@@ -116,6 +117,7 @@ jobs:
     uses: ./.github/workflows/build-android.yml
     with:
       build_mode: release
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 4: Build Windows client (release mode)
@@ -126,6 +128,7 @@ jobs:
     uses: ./.github/workflows/build-client.yml
     with:
       build_mode: release
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 5: Build Java Fabric Mod
@@ -136,6 +139,7 @@ jobs:
     uses: ./.github/workflows/build-mod-fabric.yml
     with:
       version: ${{ needs.prepare-release.outputs.new_version }}
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 5b: Build Java Paper Plugin
@@ -146,6 +150,7 @@ jobs:
     uses: ./.github/workflows/build-mod-paper.yml
     with:
       version: ${{ needs.prepare-release.outputs.new_version }}
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 5c: Build Java Hytale Plugin (conditional on HYTALE_ENABLED)
@@ -156,6 +161,7 @@ jobs:
     uses: ./.github/workflows/build-mod-hytale.yml
     with:
       version: ${{ needs.prepare-release.outputs.new_version }}
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 6: Build BDS Pack
@@ -164,6 +170,8 @@ jobs:
     needs: prepare-release
     if: needs.prepare-release.outputs.new_release == 'true' && inputs.dry_run == false
     uses: ./.github/workflows/build-mod-bds.yml
+    with:
+      ref: ${{ needs.prepare-release.outputs.new_tag }}
     secrets: inherit
 
   # Job 7: Upload release assets to GitHub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bedrock-voice-chat-client"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "anyhow",
  "async-mutex",


### PR DESCRIPTION
Fixes an issue where the release semantics would correctly tag an update but build the previous version.