### PR TITLE
refactor: hytale session id in header

### DIFF
--- a/client/src-tauri/src/auth/hytale.rs
+++ b/client/src-tauri/src/auth/hytale.rs
@@ -151,8 +151,12 @@ pub async fn poll_hytale_status(
         )
         .unwrap(),
     );
+    headers.insert(
+        "X-Session-Id",
+        tauri_plugin_http::reqwest::header::HeaderValue::from_str(&session_id).unwrap(),
+    );
 
-    let endpoint = format!("{}/api/auth/hytale/status/{}", &server, session_id);
+    let endpoint = format!("{}/api/auth/hytale/status", &server);
     let client = ncryptf::get_reqwest_client();
 
     match client.get(endpoint).headers(headers).send().await {

--- a/server/server/src/rs/guards/hytale_session_id.rs
+++ b/server/server/src/rs/guards/hytale_session_id.rs
@@ -1,0 +1,25 @@
+use rocket::{
+    async_trait,
+    http::Status,
+    request::{FromRequest, Outcome, Request},
+};
+
+#[derive(Clone, Debug)]
+pub struct HytaleSessionId(pub String);
+
+#[derive(Debug)]
+pub enum HytaleSessionIdError {
+    Missing,
+}
+
+#[async_trait]
+impl<'r> FromRequest<'r> for HytaleSessionId {
+    type Error = HytaleSessionIdError;
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match req.headers().get_one("X-Session-Id") {
+            Some(session_id) => Outcome::Success(HytaleSessionId(session_id.to_string())),
+            None => Outcome::Error((Status::BadRequest, HytaleSessionIdError::Missing)),
+        }
+    }
+}

--- a/server/server/src/rs/guards/mod.rs
+++ b/server/server/src/rs/guards/mod.rs
@@ -1,5 +1,8 @@
 mod access_token;
 //pub(crate) use access_token::AccessToken;
 
+mod hytale_session_id;
+pub(crate) use hytale_session_id::HytaleSessionId;
+
 mod mc_access_token;
 pub(crate) use mc_access_token::MCAccessToken;

--- a/server/server/src/rs/routes/api/auth/hytale.rs
+++ b/server/server/src/rs/routes/api/auth/hytale.rs
@@ -16,6 +16,7 @@ use crate::config::ApplicationConfigServer;
 use crate::rs::pool::AppDb;
 use crate::rs::dtos::ncryptf::JsonMessage;
 use crate::rs::dtos::{HytaleSession, HytaleSessionCache};
+use crate::rs::guards::HytaleSessionId;
 use crate::services::{AuthError, AuthService};
 
 /// Start a new Hytale device code flow
@@ -61,14 +62,15 @@ pub async fn start_device_flow(
 }
 
 /// Poll the status of a Hytale device code flow
-#[get("/auth/hytale/status/<session_id>")]
+#[get("/auth/hytale/status")]
 pub async fn poll_status(
     db: SeaOrmConnection<'_, AppDb>,
     config: &State<ApplicationConfigServer>,
     session_cache: &State<HytaleSessionCache>,
-    session_id: &str,
+    session_id: HytaleSessionId,
 ) -> ncryptf::rocket::JsonResponse<JsonMessage<HytaleDeviceFlowStatusResponse>> {
     let conn = db.into_inner();
+    let session_id = &session_id.0;
 
     // Look up the session
     let session = match session_cache.get(session_id).await {


### PR DESCRIPTION
## Description
Refactors the Hytale implementation so the session id is present in the header rather than the URL arguments

Fixes #98 

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).