### PR TITLE
Fix/volume gain

### DIFF
--- a/client/src-tauri/src/audio/stream/stream_manager/sink_manager.rs
+++ b/client/src-tauri/src/audio/stream/stream_manager/sink_manager.rs
@@ -86,6 +86,12 @@ where
     }
 }
 
+/// Convert a linear slider position (0.0-1.5) to a perceptually-correct amplitude factor.
+/// Uses a power curve (x^2.5) so equal slider increments produce roughly equal loudness changes.
+fn perceptual_gain(linear_position: f32) -> f32 {
+    linear_position.powf(2.5)
+}
+
 #[derive(Clone, Default)]
 struct PlayerSinks {
     normal: Option<Arc<AudioSink>>,
@@ -301,7 +307,7 @@ impl SinkManager {
                         } else {
                             1.0
                         };
-                        let volume = spatial_data.gain * gain_settings.gain * mute_mult;
+                        let volume = spatial_data.gain * perceptual_gain(gain_settings.gain) * mute_mult;
                         spatial_sink.update_spatial_position(
                             &emitter_coordinate,
                             &spatial_data.left_ear,
@@ -354,7 +360,7 @@ impl SinkManager {
                         } else {
                             1.0
                         };
-                        let volume = 1.3 * gain_settings.gain * mute_mult;
+                        let volume = 1.3 * perceptual_gain(gain_settings.gain) * mute_mult;
                         normal_sink.update_spatial_position(
                             &Coordinate::default(),
                             &Coordinate::default(),


### PR DESCRIPTION
## Description

The entire volume pipeline was using linear multiplication. The   slider value (0.0–1.5) was passed directly as sample * factor via Rodio's Amplify filter. Going from 100% → 150% only produced a +3.5 dB boost — barely perceptible to human ears.

Added a perceptual_gain() function in sink_manager.rs that applies a power curve (x^2.5) to the slider value before it reaches Rodio. This was applied at both volume calculation sites (spatial and normal audio paths).

Effect on the 100–150% range:
- Before: 1.0 → 1.5 linear factor = +3.5 dB (barely noticeable) 
- After: 1.0 → 2.756 factor = +8.8 dB (clearly louder)

Key properties preserved:
- 0% = silence (0^2.5 = 0)
- 100% = unity gain (1^2.5 = 1) — no change at the default      
- The slider now feels proportional across its entire range 

Fixes #119 

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).