### PR TITLE
fix: recording length was capped at 33:20 instead of the actual length

### DIFF
--- a/client/src-tauri/examples/render_audio.rs
+++ b/client/src-tauri/examples/render_audio.rs
@@ -1,7 +1,8 @@
 use std::env;
 use std::path::Path;
 
-use bvc_client_lib::audio::recording::renderer::{AudioFormat, AudioFormatRenderer};
+use bvc_client_lib::audio::recording::renderer::AudioFormatRenderer;
+use common::structs::AudioFormat;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,7 +24,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let player_name = &args[2];
     let output_path = Path::new(&args[3]);
 
-    let format = AudioFormat::Bwav;
+    let format = match output_path.extension().and_then(|e| e.to_str()) {
+        Some("m4a") => AudioFormat::Mp4Opus,
+        _ => AudioFormat::Bwav,
+    };
 
     println!("Rendering audio for player '{}' from session at {:?}", player_name, session_path);
     println!("Output file: {:?}", output_path);

--- a/client/src-tauri/src/audio/recording/renderer/mod.rs
+++ b/client/src-tauri/src/audio/recording/renderer/mod.rs
@@ -245,8 +245,6 @@ impl WalAudioReader {
         const NANO_REC_SIGNATURE: [u8; 6] = *b"NANORC";
         const MAX_HEADER_SIZE: usize = 1024;
         const MAX_CONTENT_SIZE: usize = 50 * 1024;
-        const MAX_RECORDS_PER_FILE: usize = 100_000;
-
         let mut entries = Vec::new();
 
         // Find all segment files for this player (files are named: PlayerName-hash-sequence.log)
@@ -268,6 +266,9 @@ impl WalAudioReader {
             log::info!("Parsing WAL file: {:?}", file_path);
 
             let file_bytes = std::fs::read(&file_path)?;
+            // Each WAL record is at minimum 16 bytes (6 signature + 2 header_len + 8 content_len),
+            // so this limit scales with file size and can never be exceeded by valid data
+            let max_records = file_bytes.len() / 16;
             let mut pos = 0;
 
             const MAX_HEADER_SEARCH_BYTES: usize = 4096;
@@ -287,7 +288,7 @@ impl WalAudioReader {
             }
 
             let mut records_parsed = 0;
-            while pos + 6 <= file_bytes.len() && records_parsed < MAX_RECORDS_PER_FILE {
+            while pos + 6 <= file_bytes.len() && records_parsed < max_records {
                 if &file_bytes[pos..pos + 6] != NANO_REC_SIGNATURE {
                     break;
                 }
@@ -355,8 +356,8 @@ impl WalAudioReader {
                 records_parsed += 1;
             }
 
-            if records_parsed >= MAX_RECORDS_PER_FILE {
-                log::warn!("Hit MAX_RECORDS_PER_FILE limit in {:?}, stopping parse", file_path);
+            if records_parsed >= max_records {
+                log::warn!("Hit max_records limit in {:?}, stopping parse", file_path);
             }
 
             log::info!("  Parsed {} total records from {:?}", records_parsed, file_path);


### PR DESCRIPTION
## Description
Fixes an issue where recording length was capped instead of allowing it to expand to the full file length

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).