### PR TITLE
fix: minor floodgate-geyser / fabric / papermc issues

### DIFF
--- a/mods/java/common/src/main/kotlin/com/alaydriem/bedrockvoicechat/config/ModConfig.kt
+++ b/mods/java/common/src/main/kotlin/com/alaydriem/bedrockvoicechat/config/ModConfig.kt
@@ -23,10 +23,6 @@ class ModConfig {
     @SerializedName(value = "embedded-config", alternate = ["embeddedConfig"])
     var embeddedConfig: EmbeddedConfig? = null
 
-    // Floodgate prefix for Bedrock players on Geyser servers without the Floodgate plugin
-    @SerializedName(value = "floodgate-prefix", alternate = ["floodgatePrefix"])
-    var floodgatePrefix: String? = null
-
     /**
      * Check if the configuration is valid.
      * For embedded mode, we don't need external server URL.

--- a/mods/java/common/src/main/kotlin/com/alaydriem/bedrockvoicechat/integration/FloodgateIntegration.kt
+++ b/mods/java/common/src/main/kotlin/com/alaydriem/bedrockvoicechat/integration/FloodgateIntegration.kt
@@ -1,62 +1,73 @@
 package com.alaydriem.bedrockvoicechat.integration
 
+import org.slf4j.LoggerFactory
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Optional integration with the Floodgate API for detecting Bedrock players on Geyser servers.
- * Safely handles the case where Floodgate is not installed (API class not found at runtime).
+ * Lazily resolves the API on first use because mod load order (especially on Fabric) can place
+ * BVC initialization before Floodgate has registered its API singleton.
  */
 class FloodgateIntegration {
-    private val available: Boolean
-    private val apiInstance: Any?
+    private val log = LoggerFactory.getLogger("BedrockVoiceChat.Floodgate")
 
-    init {
-        var api: Any? = null
-        var isAvailable = false
+    private enum class State { UNRESOLVED, AVAILABLE, ABSENT }
+    private val state = AtomicReference(State.UNRESOLVED)
+    @Volatile private var apiInstance: Any? = null
+
+    val isAvailable: Boolean get() = resolveApi() != null
+
+    private fun resolveApi(): Any? {
+        when (state.get()) {
+            State.AVAILABLE -> return apiInstance
+            State.ABSENT -> return null
+            State.UNRESOLVED -> Unit
+        }
         try {
             val clazz = Class.forName("org.geysermc.floodgate.api.FloodgateApi")
-            val getInstance = clazz.getMethod("getInstance")
-            api = getInstance.invoke(null)
-            isAvailable = true
-        } catch (_: Exception) {
-            // Floodgate not installed
+            val api = clazz.getMethod("getInstance").invoke(null)
+            if (api != null) {
+                apiInstance = api
+                state.set(State.AVAILABLE)
+                log.info("Floodgate API loaded: impl={}", api.javaClass.name)
+                return api
+            }
+            return null
+        } catch (e: ClassNotFoundException) {
+            state.set(State.ABSENT)
+            log.info("Floodgate API not found on classpath — prefix-strip path disabled")
+            return null
+        } catch (e: Exception) {
+            log.warn("Failed to load Floodgate API: {}", e.toString())
+            return null
         }
-        this.apiInstance = api
-        this.available = isAvailable
     }
 
-    val isAvailable: Boolean get() = available
-
-    /**
-     * Get the Xbox gamertag for a Floodgate (Bedrock) player.
-     * Returns null if Floodgate is not installed or the player is not a Bedrock player.
-     */
     fun getXboxGamertag(playerUuid: UUID): String? {
-        val api = apiInstance ?: return null
+        val api = resolveApi() ?: return null
         try {
             val apiClass = api.javaClass
             val isFloodgate = apiClass.getMethod("isFloodgatePlayer", UUID::class.java)
-            if (isFloodgate.invoke(api, playerUuid) != true) return null
+            val floodgateResult = isFloodgate.invoke(api, playerUuid)
+            if (floodgateResult != true) {
+                log.info("isFloodgatePlayer({}) returned {} — not stripping prefix", playerUuid, floodgateResult)
+                return null
+            }
 
             val getPlayer = apiClass.getMethod("getPlayer", UUID::class.java)
-            val floodgatePlayer = getPlayer.invoke(api, playerUuid) ?: return null
+            val floodgatePlayer = getPlayer.invoke(api, playerUuid)
+            if (floodgatePlayer == null) {
+                log.info("getPlayer({}) returned null despite isFloodgatePlayer=true", playerUuid)
+                return null
+            }
 
             val playerClass = floodgatePlayer.javaClass
-            return try {
-                // getCorrectUsername() returns the actual Xbox/Bedrock gamertag,
-                // whereas getUsername() returns the Java-visible name (which may include prefix)
-                val getCorrectUsername = playerClass.getMethod("getCorrectUsername")
-                getCorrectUsername.invoke(floodgatePlayer) as? String
-            } catch (_: Exception) {
-                // Fall back to getUsername if getCorrectUsername is not available
-                try {
-                    val getUsername = playerClass.getMethod("getUsername")
-                    getUsername.invoke(floodgatePlayer) as? String
-                } catch (_: Exception) {
-                    null
-                }
-            }
-        } catch (_: Exception) {
+            // getUsername() returns the raw Bedrock gamertag (no prefix);
+            // getJavaUsername() / getCorrectUsername() return the Java-visible name (with prefix)
+            return playerClass.getMethod("getUsername").invoke(floodgatePlayer) as? String
+        } catch (e: Exception) {
+            log.warn("Floodgate API call failed for {}: {}", playerUuid, e.toString())
             return null
         }
     }

--- a/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/FabricMod.kt
+++ b/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/FabricMod.kt
@@ -46,9 +46,7 @@ class FabricMod : ModInitializer {
         }
 
         minimumPlayers = config.minimumPlayers
-        playerDataProvider = FabricPlayerDataProvider(
-            floodgatePrefix = config.floodgatePrefix
-        )
+        playerDataProvider = FabricPlayerDataProvider()
 
         if (config.useEmbeddedServer) {
             embeddedServer = BvcServerManager(config, configProvider)
@@ -83,12 +81,13 @@ class FabricMod : ModInitializer {
         ServerPlayConnectionEvents.DISCONNECT.register { handler, _ ->
             val player = handler.player
             val sender = positionSender
+            val canonicalName = playerDataProvider.resolveCanonicalName(player)
 
             // Capture phantom data before removePlayer() clears state
             val phantom = if (sender != null) {
                 val worldUuid = playerDataProvider.getWorldUuid(player.entityWorld as ServerWorld)
                 PlayerData.disconnected(
-                    name = player.name.string,
+                    name = canonicalName,
                     dimension = Dimension.Minecraft.DEATH,
                     worldUuid = worldUuid,
                     playerUuid = player.uuid.toString()
@@ -100,7 +99,7 @@ class FabricMod : ModInitializer {
             if (phantom != null && sender != null) {
                 val payload = Payload(playerDataProvider.getGameType(), listOf(phantom))
                 sender.send(payload)
-                logger.info("Sent disconnect phantom for player: {}", player.name.string)
+                logger.info("Sent disconnect phantom for player: {}", canonicalName)
             }
         }
 

--- a/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/FabricPlayerDataProvider.kt
+++ b/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/FabricPlayerDataProvider.kt
@@ -8,6 +8,7 @@ import com.alaydriem.bedrockvoicechat.integration.FloodgateIntegration
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -18,9 +19,10 @@ import java.util.concurrent.ConcurrentHashMap
  * Stores UUIDs and looks up fresh player references each tick to avoid stale entity references.
  */
 class FabricPlayerDataProvider(
-    private val floodgate: FloodgateIntegration = FloodgateIntegration(),
-    private val floodgatePrefix: String? = null
+    private val floodgate: FloodgateIntegration = FloodgateIntegration()
 ) : PlayerDataProvider {
+    private val log = LoggerFactory.getLogger("BedrockVoiceChat.Identity")
+    private val loggedIdentities: MutableSet<String> = ConcurrentHashMap.newKeySet()
     var server: MinecraftServer? = null
 
     private val onlinePlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
@@ -52,13 +54,13 @@ class FabricPlayerDataProvider(
             .filter { !it.isDisconnected }
             .map { player ->
                 val worldUuid = getWorldUuid(player.entityWorld as ServerWorld)
-                val altIdentity = resolveAlternativeIdentity(player)
+                val identity = resolveIdentity(player)
                 val playerUuid = player.uuid.toString()
 
                 // Check if player is dead - override to death dimension at origin
                 if (deadPlayers.contains(player.uuid)) {
                     PlayerData(
-                        name = player.name.string,
+                        name = identity.name,
                         x = 0.0,
                         y = 0.0,
                         z = 0.0,
@@ -68,14 +70,14 @@ class FabricPlayerDataProvider(
                         deafen = false,
                         spectator = false,
                         worldUuid = worldUuid,
-                        alternativeIdentity = altIdentity,
+                        alternativeIdentity = identity.alternative,
                         playerUuid = playerUuid
                     )
                 } else {
                     // Normal player data
                     val dimension = getDimensionFromPlayer(player)
                     PlayerData(
-                        name = player.name.string,
+                        name = identity.name,
                         x = player.x,
                         y = player.y,
                         z = player.z,
@@ -85,37 +87,36 @@ class FabricPlayerDataProvider(
                         deafen = player.isSneaking,
                         spectator = player.isSpectator,
                         worldUuid = worldUuid,
-                        alternativeIdentity = altIdentity,
+                        alternativeIdentity = identity.alternative,
                         playerUuid = playerUuid
                     )
                 }
             }
     }
 
-    /**
-     * Resolve the alternative identity (Xbox gamertag) for a player.
-     * Tries Floodgate API first, then falls back to prefix stripping from config.
-     */
-    private fun resolveAlternativeIdentity(player: ServerPlayerEntity): String? {
-        val playerName = player.name.string
-        val result = resolveRawAlternativeIdentity(player, playerName)
-        // No mapping needed if the resolved identity matches the player name
-        if (result != null && result == playerName) return null
-        return result
-    }
+    fun resolveCanonicalName(player: ServerPlayerEntity): String = resolveIdentity(player).name
 
-    private fun resolveRawAlternativeIdentity(player: ServerPlayerEntity, playerName: String): String? {
-        // Try Floodgate API first
-        val floodgateGamertag = floodgate.getXboxGamertag(player.uuid)
-        if (floodgateGamertag != null) return floodgateGamertag
+    private data class Identity(val name: String, val alternative: String?)
 
-        // Fall back to prefix stripping if configured
-        val prefix = floodgatePrefix
-        if (prefix != null && playerName.startsWith(prefix)) {
-            return playerName.removePrefix(prefix)
+    private fun resolveIdentity(player: ServerPlayerEntity): Identity {
+        val javaName = player.name.string
+        val canonical = floodgate.getXboxGamertag(player.uuid)
+        val identity = when {
+            canonical == null -> Identity(javaName, null)
+            javaName == canonical -> Identity(javaName, null)
+            // Floodgate prefix is applied to this player — strip it so they register under their canonical Xbox gamertag
+            javaName.endsWith(canonical) -> Identity(canonical, null)
+            // Linked Bedrock player with a different Java account name — keep the Java identity, expose canonical as alias
+            else -> Identity(javaName, canonical)
         }
-
-        return null
+        val logKey = "${player.uuid}|$javaName|$canonical"
+        if (loggedIdentities.add(logKey)) {
+            log.info(
+                "Identity resolution: uuid={}, javaName='{}', canonical='{}' -> name='{}', alt='{}'",
+                player.uuid, javaName, canonical, identity.name, identity.alternative
+            )
+        }
+        return identity
     }
 
     override fun getGameType(): GameType = GameType.MINECRAFT

--- a/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/audio/JukeboxListener.kt
+++ b/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/audio/JukeboxListener.kt
@@ -8,6 +8,7 @@ import net.minecraft.block.JukeboxBlock
 import net.minecraft.block.entity.JukeboxBlockEntity
 import net.minecraft.component.DataComponentTypes
 import net.minecraft.component.type.NbtComponent
+import net.minecraft.entity.ItemEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.particle.ParticleTypes
@@ -18,6 +19,7 @@ import net.minecraft.util.ActionResult
 import net.minecraft.util.Hand
 import net.minecraft.util.ItemScatterer
 import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Box
 import net.minecraft.world.World
 
 class JukeboxListener(
@@ -26,7 +28,15 @@ class JukeboxListener(
 ) {
     private data class ActiveJukebox(val pos: BlockPos, val ejectTick: Long)
 
+    private data class PendingEjectCheck(
+        val world: ServerWorld,
+        val pos: BlockPos,
+        val key: String,
+        val tickAt: Long
+    )
+
     private val activeJukeboxes = mutableMapOf<String, ActiveJukebox>()
+    private val pendingEjectChecks = mutableListOf<PendingEjectCheck>()
     private var particleTickCounter = 0
 
     init {
@@ -42,14 +52,35 @@ class JukeboxListener(
             val state = world.getBlockState(pos)
             if (state.block != Blocks.JUKEBOX) return@register ActionResult.PASS
 
+            val heldItem = player.getStackInHand(hand)
+            val isHoldingBvcDisc = heldItem.item == Items.MUSIC_DISC_5 && isBvcDisc(heldItem)
+
+            val serverWorld = world as ServerWorld
+            val worldUuid = worldUuidResolver(serverWorld)
+            val key = audioPlayerManager.locationKey(worldUuid, pos.x, pos.y, pos.z)
+            val hasActiveBvcPlayback = audioPlayerManager.hasActivePlayback(key)
+
+            if (!isHoldingBvcDisc && !hasActiveBvcPlayback) return@register ActionResult.PASS
+
             val jukebox = world.getBlockEntity(pos) as? JukeboxBlockEntity
                 ?: return@register ActionResult.PASS
 
-            val heldItem = player.getStackInHand(hand)
+            if (hasActiveBvcPlayback) {
+                if (heldItem.isEmpty) {
+                    audioPlayerManager.stopPlayback(key)
+                    activeJukeboxes.remove(key)
+                    ejectDisc(serverWorld, pos, jukebox)
+                    return@register ActionResult.SUCCESS
+                }
 
-            if (heldItem.item == Items.MUSIC_DISC_5 && isBvcDisc(heldItem)) {
-                if (!jukebox.stack.isEmpty) return@register ActionResult.PASS
+                val server = serverWorld.server ?: return@register ActionResult.PASS
+                pendingEjectChecks.add(
+                    PendingEjectCheck(serverWorld, pos.toImmutable(), key, server.ticks + 1L)
+                )
+                return@register ActionResult.PASS
+            }
 
+            if (isHoldingBvcDisc && jukebox.stack.isEmpty) {
                 val disc = heldItem.copyWithCount(1)
                 heldItem.decrement(1)
                 jukebox.setDisc(disc)
@@ -59,8 +90,6 @@ class JukeboxListener(
 
                 val audioId = getAudioId(disc) ?: return@register ActionResult.SUCCESS
                 val dimensionId = getDimensionId(world)
-                val worldUuid = worldUuidResolver(world as ServerWorld)
-                val key = audioPlayerManager.locationKey(worldUuid, pos.x, pos.y, pos.z)
 
                 audioPlayerManager.startPlayback(
                     audioId, dimensionId,
@@ -77,34 +106,26 @@ class JukeboxListener(
 
                 (player as? ServerPlayerEntity)?.sendMessage(Text.empty(), true)
 
-                ActionResult.SUCCESS
-            } else if (heldItem.isEmpty) {
-                val record = jukebox.stack
-                if (record.isEmpty || !isBvcDisc(record)) return@register ActionResult.PASS
-
-                val worldUuid = worldUuidResolver(world as ServerWorld)
-                val key = audioPlayerManager.locationKey(worldUuid, pos.x, pos.y, pos.z)
-                audioPlayerManager.stopPlayback(key)
-                activeJukeboxes.remove(key)
-                ejectDisc(world as ServerWorld, pos, jukebox)
-
-                ActionResult.SUCCESS
-            } else {
-                ActionResult.PASS
+                return@register ActionResult.SUCCESS
             }
+
+            ActionResult.PASS
         }
 
-        PlayerBlockBreakEvents.BEFORE.register { world, player, pos, state, blockEntity ->
+        PlayerBlockBreakEvents.BEFORE.register { world, _, pos, state, blockEntity ->
             if (state.block != Blocks.JUKEBOX) return@register true
-            val jukebox = blockEntity as? JukeboxBlockEntity ?: return@register true
-            if (jukebox.stack.isEmpty || !isBvcDisc(jukebox.stack)) return@register true
 
-            restoreJukeboxPlayable(jukebox.stack)
+            val jukebox = blockEntity as? JukeboxBlockEntity
+            if (jukebox != null && !jukebox.stack.isEmpty && isBvcDisc(jukebox.stack)) {
+                restoreJukeboxPlayable(jukebox.stack)
+            }
 
             val key = audioPlayerManager.locationKey(
                 worldUuidResolver(world as ServerWorld), pos.x, pos.y, pos.z
             )
-            audioPlayerManager.stopPlayback(key)
+            if (audioPlayerManager.hasActivePlayback(key)) {
+                audioPlayerManager.stopPlayback(key)
+            }
             activeJukeboxes.remove(key)
             true
         }
@@ -112,7 +133,14 @@ class JukeboxListener(
         ServerTickEvents.END_SERVER_TICK.register { server ->
             val currentTick = server.ticks.toLong()
 
-            // Auto-eject expired jukeboxes
+            if (pendingEjectChecks.isNotEmpty()) {
+                val due = pendingEjectChecks.filter { it.tickAt <= currentTick }
+                pendingEjectChecks.removeAll(due)
+                for (check in due) {
+                    processEjectCheck(check)
+                }
+            }
+
             val toEject = mutableListOf<String>()
             for ((key, active) in activeJukeboxes) {
                 if (currentTick >= active.ejectTick) {
@@ -131,7 +159,6 @@ class JukeboxListener(
                 }
             }
 
-            // Spawn note particles every 20 ticks
             particleTickCounter++
             if (particleTickCounter < 20) return@register
             particleTickCounter = 0
@@ -150,6 +177,44 @@ class JukeboxListener(
                 }
             }
         }
+    }
+
+    private fun processEjectCheck(check: PendingEjectCheck) {
+        val world = check.world
+        val pos = check.pos
+        val key = check.key
+
+        if (world.getBlockState(pos).block != Blocks.JUKEBOX) {
+            cleanupAfterEject(key)
+            return
+        }
+
+        val jukebox = world.getBlockEntity(pos) as? JukeboxBlockEntity
+        val stillHasBvc = jukebox != null && !jukebox.stack.isEmpty && isBvcDisc(jukebox.stack)
+        if (stillHasBvc) return
+
+        cleanupAfterEject(key)
+
+        val cx = pos.x + 0.5
+        val cy = pos.y + 0.5
+        val cz = pos.z + 0.5
+        val box = Box(cx - 2.0, cy - 2.0, cz - 2.0, cx + 2.0, cy + 2.0, cz + 2.0)
+        val items = world.getEntitiesByClass(ItemEntity::class.java, box) { entity ->
+            val stack = entity.stack
+            stack.item == Items.MUSIC_DISC_5 && isBvcDisc(stack)
+        }
+        for (entity in items) {
+            val stack = entity.stack
+            restoreJukeboxPlayable(stack)
+            entity.stack = stack
+        }
+    }
+
+    private fun cleanupAfterEject(key: String) {
+        if (audioPlayerManager.hasActivePlayback(key)) {
+            audioPlayerManager.stopPlayback(key)
+        }
+        activeJukeboxes.remove(key)
     }
 
     companion object {
@@ -214,6 +279,7 @@ class JukeboxListener(
                 nbt.putBoolean(BVC_DISC_TAG, true)
                 nbt.putString(AUDIO_ID_TAG, audioId)
             }
+            disc.remove(DataComponentTypes.JUKEBOX_PLAYABLE)
             return disc
         }
 

--- a/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/commands/DiscCommand.kt
+++ b/mods/java/fabric/src/main/kotlin/com/alaydriem/bedrockvoicechat/fabric/commands/DiscCommand.kt
@@ -4,6 +4,7 @@ import com.alaydriem.bedrockvoicechat.fabric.audio.JukeboxListener
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
+import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.command.permission.Permission
 import net.minecraft.command.permission.PermissionLevel
 import net.minecraft.component.DataComponentTypes
@@ -17,12 +18,19 @@ object DiscCommand {
                 CommandManager.literal("bvc")
                     .then(
                         CommandManager.literal("disc")
-                            .requires { it.permissions.hasPermission(Permission.Level(PermissionLevel.GAMEMASTERS)) }
                             .then(
-                                CommandManager.argument("audio_id", StringArgumentType.string())
+                                CommandManager.argument("audio_id", StringArgumentType.greedyString())
                                     .executes { ctx ->
                                         val audioId = StringArgumentType.getString(ctx, "audio_id")
-                                        val player = ctx.source.playerOrThrow
+                                        val player = ctx.source.player
+                                        if (player == null) {
+                                            ctx.source.sendError(
+                                                Text.literal(
+                                                    "/bvc disc must be run by a player. Use /bvc give <player> <audio_id> from the console."
+                                                )
+                                            )
+                                            return@executes 0
+                                        }
 
                                         val disc = JukeboxListener.createBvcDisc(audioId)
                                         disc.set(DataComponentTypes.CUSTOM_NAME, Text.literal("BVC: $audioId"))
@@ -38,6 +46,46 @@ object DiscCommand {
 
                                         Command.SINGLE_SUCCESS
                                     }
+                            )
+                    )
+                    .then(
+                        CommandManager.literal("give")
+                            .requires { it.permissions.hasPermission(Permission.Level(PermissionLevel.GAMEMASTERS)) }
+                            .then(
+                                CommandManager.argument("target", EntityArgumentType.players())
+                                    .then(
+                                        CommandManager.argument("audio_id", StringArgumentType.greedyString())
+                                            .executes { ctx ->
+                                                val audioId = StringArgumentType.getString(ctx, "audio_id")
+                                                val targets = EntityArgumentType.getPlayers(ctx, "target")
+                                                if (targets.isEmpty()) {
+                                                    ctx.source.sendError(Text.literal("No matching player found"))
+                                                    return@executes 0
+                                                }
+
+                                                for (target in targets) {
+                                                    val disc = JukeboxListener.createBvcDisc(audioId)
+                                                    disc.set(
+                                                        DataComponentTypes.CUSTOM_NAME,
+                                                        Text.literal("BVC: $audioId")
+                                                    )
+                                                    if (!target.inventory.insertStack(disc)) {
+                                                        target.dropItem(disc, false)
+                                                    }
+                                                }
+
+                                                ctx.source.sendFeedback(
+                                                    {
+                                                        Text.literal(
+                                                            "Gave BVC audio disc '$audioId' to ${targets.size} player(s)"
+                                                        )
+                                                    },
+                                                    true
+                                                )
+
+                                                Command.SINGLE_SUCCESS
+                                            }
+                                    )
                             )
                     )
             )

--- a/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/PaperPlayerDataProvider.kt
+++ b/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/PaperPlayerDataProvider.kt
@@ -7,6 +7,7 @@ import com.alaydriem.bedrockvoicechat.dto.PlayerData
 import com.alaydriem.bedrockvoicechat.integration.FloodgateIntegration
 import org.bukkit.World
 import org.bukkit.entity.Player
+import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -16,9 +17,10 @@ import java.util.concurrent.ConcurrentHashMap
  * Stores UUIDs and looks up fresh player references each tick to avoid stale entity references.
  */
 class PaperPlayerDataProvider(
-    private val floodgate: FloodgateIntegration = FloodgateIntegration(),
-    private val floodgatePrefix: String? = null
+    private val floodgate: FloodgateIntegration = FloodgateIntegration()
 ) : PlayerDataProvider {
+    private val log = LoggerFactory.getLogger("BedrockVoiceChat.Identity")
+    private val loggedIdentities: MutableSet<String> = ConcurrentHashMap.newKeySet()
     var server: org.bukkit.Server? = null
 
     private val onlinePlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
@@ -48,13 +50,13 @@ class PaperPlayerDataProvider(
             .mapNotNull { uuid -> srv.getPlayer(uuid) }
             .filter { it.isOnline }
             .map { player ->
-                val altIdentity = resolveAlternativeIdentity(player)
+                val identity = resolveIdentity(player)
                 val playerUuid = player.uniqueId.toString()
 
                 // Check if player is dead - override to death dimension at origin
                 if (deadPlayers.contains(player.uniqueId)) {
                     PlayerData(
-                        name = player.name,
+                        name = identity.name,
                         x = 0.0,
                         y = 0.0,
                         z = 0.0,
@@ -64,7 +66,7 @@ class PaperPlayerDataProvider(
                         deafen = false,
                         spectator = false,
                         worldUuid = player.location.world?.uid?.toString(),
-                        alternativeIdentity = altIdentity,
+                        alternativeIdentity = identity.alternative,
                         playerUuid = playerUuid
                     )
                 } else {
@@ -72,7 +74,7 @@ class PaperPlayerDataProvider(
                     val location = player.location
                     val dimension = getDimension(location.world)
                     PlayerData(
-                        name = player.name,
+                        name = identity.name,
                         x = location.x,
                         y = location.y,
                         z = location.z,
@@ -82,36 +84,36 @@ class PaperPlayerDataProvider(
                         deafen = player.isSneaking,
                         spectator = player.gameMode == org.bukkit.GameMode.SPECTATOR,
                         worldUuid = location.world?.uid?.toString(),
-                        alternativeIdentity = altIdentity,
+                        alternativeIdentity = identity.alternative,
                         playerUuid = playerUuid
                     )
                 }
             }
     }
 
-    /**
-     * Resolve the alternative identity (Xbox gamertag) for a player.
-     * Tries Floodgate API first, then falls back to prefix stripping from config.
-     */
-    private fun resolveAlternativeIdentity(player: Player): String? {
-        val result = resolveRawAlternativeIdentity(player)
-        // No mapping needed if the resolved identity matches the player name
-        if (result != null && result == player.name) return null
-        return result
-    }
+    fun resolveCanonicalName(player: Player): String = resolveIdentity(player).name
 
-    private fun resolveRawAlternativeIdentity(player: Player): String? {
-        // Try Floodgate API first
-        val floodgateGamertag = floodgate.getXboxGamertag(player.uniqueId)
-        if (floodgateGamertag != null) return floodgateGamertag
+    private data class Identity(val name: String, val alternative: String?)
 
-        // Fall back to prefix stripping if configured
-        val prefix = floodgatePrefix
-        if (prefix != null && player.name.startsWith(prefix)) {
-            return player.name.removePrefix(prefix)
+    private fun resolveIdentity(player: Player): Identity {
+        val javaName = player.name
+        val canonical = floodgate.getXboxGamertag(player.uniqueId)
+        val identity = when {
+            canonical == null -> Identity(javaName, null)
+            javaName == canonical -> Identity(javaName, null)
+            // Floodgate prefix is applied to this player — strip it so they register under their canonical Xbox gamertag
+            javaName.endsWith(canonical) -> Identity(canonical, null)
+            // Linked Bedrock player with a different Java account name — keep the Java identity, expose canonical as alias
+            else -> Identity(javaName, canonical)
         }
-
-        return null
+        val logKey = "${player.uniqueId}|$javaName|$canonical"
+        if (loggedIdentities.add(logKey)) {
+            log.info(
+                "Identity resolution: uuid={}, javaName='{}', canonical='{}' -> name='{}', alt='{}'",
+                player.uniqueId, javaName, canonical, identity.name, identity.alternative
+            )
+        }
+        return identity
     }
 
     override fun getGameType(): GameType = GameType.MINECRAFT

--- a/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/PaperPlugin.kt
+++ b/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/PaperPlugin.kt
@@ -51,9 +51,7 @@ class PaperPlugin : JavaPlugin(), Listener {
         }
 
         minimumPlayers = config.minimumPlayers
-        playerDataProvider = PaperPlayerDataProvider(
-            floodgatePrefix = config.floodgatePrefix
-        )
+        playerDataProvider = PaperPlayerDataProvider()
 
         // Initialize embedded server if configured
         if (config.useEmbeddedServer) {
@@ -129,11 +127,12 @@ class PaperPlugin : JavaPlugin(), Listener {
     fun onPlayerQuit(event: PlayerQuitEvent) {
         val player = event.player
         val sender = positionSender
+        val canonicalName = playerDataProvider.resolveCanonicalName(player)
 
         // Capture phantom data before removePlayer() clears state
         val phantom = if (sender != null) {
             PlayerData.disconnected(
-                name = player.name,
+                name = canonicalName,
                 dimension = Dimension.Minecraft.DEATH,
                 worldUuid = player.location.world?.uid?.toString(),
                 playerUuid = player.uniqueId.toString()
@@ -145,7 +144,7 @@ class PaperPlugin : JavaPlugin(), Listener {
         if (phantom != null && sender != null) {
             val payload = Payload(playerDataProvider.getGameType(), listOf(phantom))
             sender.send(payload)
-            logger.info("Sent disconnect phantom for player: ${player.name}")
+            logger.info("Sent disconnect phantom for player: $canonicalName")
         }
     }
 

--- a/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/audio/JukeboxListener.kt
+++ b/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/audio/JukeboxListener.kt
@@ -1,10 +1,13 @@
 package com.alaydriem.bedrockvoicechat.paper.audio
 
+import io.papermc.paper.datacomponent.DataComponentTypes
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.World
+import org.bukkit.block.Block
 import org.bukkit.block.Jukebox
+import org.bukkit.entity.Item
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
@@ -17,6 +20,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.plugin.java.JavaPlugin
 
+@Suppress("UnstableApiUsage")
 class JukeboxListener(
     private val audioPlayerManager: PaperAudioPlayerManager,
     private val plugin: JavaPlugin
@@ -32,65 +36,105 @@ class JukeboxListener(
         val block = event.clickedBlock ?: return
         if (block.type != Material.JUKEBOX) return
 
-        val jukebox = block.state as? Jukebox ?: return
         val item = event.item
+        val isHoldingBvcDisc = item != null && item.type == Material.MUSIC_DISC_5 && isBvcDisc(item)
 
-        if (item != null && item.type == Material.MUSIC_DISC_5 && isBvcDisc(item)) {
-            if (jukebox.hasRecord()) return
+        val key = audioPlayerManager.locationKey(
+            block.world.uid.toString(), block.x, block.y, block.z
+        )
+        val hasActiveBvcPlayback = audioPlayerManager.hasActivePlayback(key)
 
-            val key = audioPlayerManager.locationKey(
-                block.world.uid.toString(), block.x, block.y, block.z
-            )
-            if (audioPlayerManager.hasActivePlayback(key)) return
+        if (!isHoldingBvcDisc && !hasActiveBvcPlayback) return
 
-            event.isCancelled = true
+        val jukebox = block.state as? Jukebox ?: return
 
-            val disc = item.clone()
-            disc.amount = 1
-            jukebox.setRecord(disc)
-            jukebox.update()
-
-            disc.editMeta { it.setJukeboxPlayable(null) }
-            jukebox.setRecord(disc)
-            jukebox.update(true)
-
-            if (item.amount <= 1) {
-                event.player.inventory.setItemInMainHand(null)
+        if (hasActiveBvcPlayback) {
+            if (item == null || item.type == Material.AIR) {
+                event.isCancelled = true
+                ejectBvcDisc(block, jukebox)
             } else {
-                item.amount--
+                scheduleEjectCleanup(block)
             }
+            return
+        }
 
-            val audioId = getAudioId(disc) ?: return
-            val world = block.world
-            val worldUuid = world.uid.toString()
-            val dimensionId = getDimensionId(world)
+        if (isHoldingBvcDisc && !jukebox.hasRecord()) {
+            insertBvcDisc(event, block, jukebox, item)
+        }
+    }
 
-            audioPlayerManager.startPlayback(
-                audioId, dimensionId,
-                block.x.toDouble(), block.y.toDouble(), block.z.toDouble(),
-                worldUuid
-            ) { _ -> }
+    private fun insertBvcDisc(event: PlayerInteractEvent, block: Block, jukebox: Jukebox, item: ItemStack) {
+        val key = audioPlayerManager.locationKey(
+            block.world.uid.toString(), block.x, block.y, block.z
+        )
+        if (audioPlayerManager.hasActivePlayback(key)) return
 
-            event.player.sendActionBar(Component.empty())
+        event.isCancelled = true
 
-        } else if (item == null || item.type == Material.AIR) {
-            if (!jukebox.hasRecord()) return
-            val record = jukebox.record
-            if (!isBvcDisc(record)) return
+        val disc = item.clone()
+        disc.amount = 1
+        disc.unsetData(DataComponentTypes.JUKEBOX_PLAYABLE)
+        jukebox.setRecord(disc)
+        jukebox.update(true)
 
-            event.isCancelled = true
+        if (item.amount <= 1) {
+            event.player.inventory.setItemInMainHand(null)
+        } else {
+            item.amount--
+        }
 
-            val disc = jukebox.record.clone()
-            restoreJukeboxPlayable(disc)
-            jukebox.setRecord(null)
-            jukebox.update(true)
-            block.world.dropItemNaturally(block.location.add(0.5, 1.0, 0.5), disc)
+        val audioId = getAudioId(disc) ?: return
+        val world = block.world
+        val worldUuid = world.uid.toString()
+        val dimensionId = getDimensionId(world)
 
-            val key = audioPlayerManager.locationKey(
-                block.world.uid.toString(), block.x, block.y, block.z
-            )
+        audioPlayerManager.startPlayback(
+            audioId, dimensionId,
+            block.x.toDouble(), block.y.toDouble(), block.z.toDouble(),
+            worldUuid
+        ) { _ -> }
+
+        event.player.sendActionBar(Component.empty())
+    }
+
+    private fun ejectBvcDisc(block: Block, jukebox: Jukebox) {
+        val disc = jukebox.record.clone()
+        restoreJukeboxPlayable(disc)
+        jukebox.setRecord(null)
+        jukebox.update(true)
+        block.world.dropItemNaturally(block.location.add(0.5, 1.0, 0.5), disc)
+
+        val key = audioPlayerManager.locationKey(
+            block.world.uid.toString(), block.x, block.y, block.z
+        )
+        if (audioPlayerManager.hasActivePlayback(key)) {
             audioPlayerManager.stopPlayback(key)
         }
+    }
+
+    private fun scheduleEjectCleanup(block: Block) {
+        val worldUuid = block.world.uid.toString()
+        val key = audioPlayerManager.locationKey(worldUuid, block.x, block.y, block.z)
+
+        plugin.server.scheduler.runTaskLater(plugin, Runnable {
+            val state = block.state as? Jukebox
+            val stillHasBvc = state?.hasRecord() == true && isBvcDisc(state.record)
+            if (stillHasBvc) return@Runnable
+
+            if (audioPlayerManager.hasActivePlayback(key)) {
+                audioPlayerManager.stopPlayback(key)
+            }
+
+            val center = block.location.add(0.5, 0.5, 0.5)
+            for (entity in block.world.getNearbyEntities(center, 2.0, 2.0, 2.0)) {
+                if (entity !is Item) continue
+                val stack = entity.itemStack
+                if (stack.type != Material.MUSIC_DISC_5) continue
+                if (!isBvcDisc(stack)) continue
+                stack.resetData(DataComponentTypes.JUKEBOX_PLAYABLE)
+                entity.itemStack = stack
+            }
+        }, 1L)
     }
 
     @EventHandler
@@ -107,7 +151,12 @@ class JukeboxListener(
         plugin.server.scheduler.runTaskLater(plugin, Runnable {
             val state = block.state as? Jukebox ?: return@Runnable
             if (!state.hasRecord()) return@Runnable
-            if (!isBvcDisc(state.record)) return@Runnable
+            val record = state.record
+            if (!isBvcDisc(record)) return@Runnable
+
+            record.unsetData(DataComponentTypes.JUKEBOX_PLAYABLE)
+            state.setRecord(record)
+            state.update(true)
 
             val worldUuid = world.uid.toString()
             val dimensionId = getDimensionId(world)
@@ -123,16 +172,19 @@ class JukeboxListener(
     fun onBlockBreak(event: BlockBreakEvent) {
         val block = event.block
         if (block.type != Material.JUKEBOX) return
-        val jukebox = block.state as? Jukebox ?: return
-        if (!jukebox.hasRecord() || !isBvcDisc(jukebox.record)) return
 
-        restoreJukeboxPlayable(jukebox.record)
-        jukebox.update(true)
+        val jukebox = block.state as? Jukebox
+        if (jukebox != null && jukebox.hasRecord() && isBvcDisc(jukebox.record)) {
+            restoreJukeboxPlayable(jukebox.record)
+            jukebox.update(true)
+        }
 
         val key = audioPlayerManager.locationKey(
             block.world.uid.toString(), block.x, block.y, block.z
         )
-        audioPlayerManager.stopPlayback(key)
+        if (audioPlayerManager.hasActivePlayback(key)) {
+            audioPlayerManager.stopPlayback(key)
+        }
     }
 
     private fun isBvcDisc(item: ItemStack?): Boolean {
@@ -156,12 +208,10 @@ class JukeboxListener(
     }
 
     companion object {
+        @Suppress("UnstableApiUsage")
         fun restoreJukeboxPlayable(disc: ItemStack) {
             if (disc.type != Material.MUSIC_DISC_5) return
-            val reference = ItemStack(Material.MUSIC_DISC_5)
-            val refMeta = reference.itemMeta ?: return
-            if (!refMeta.hasJukeboxPlayable()) return
-            disc.editMeta { it.setJukeboxPlayable(refMeta.jukeboxPlayable) }
+            disc.resetData(DataComponentTypes.JUKEBOX_PLAYABLE)
         }
     }
 }

--- a/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/commands/DiscCommand.kt
+++ b/mods/java/paper/src/main/kotlin/com/alaydriem/bedrockvoicechat/paper/commands/DiscCommand.kt
@@ -3,6 +3,9 @@ package com.alaydriem.bedrockvoicechat.paper.commands
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import io.papermc.paper.command.brigadier.Commands
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes
+import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver
+import io.papermc.paper.datacomponent.DataComponentTypes
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
 import net.kyori.adventure.text.Component
 import org.bukkit.Material
@@ -12,6 +15,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.plugin.java.JavaPlugin
 
+@Suppress("UnstableApiUsage")
 class DiscCommand(private val plugin: JavaPlugin) {
 
     private val isBvcDiscKey = NamespacedKey(plugin, "is_bvc_disc")
@@ -25,19 +29,58 @@ class DiscCommand(private val plugin: JavaPlugin) {
                         Commands.literal("disc")
                             .requires { it.sender.hasPermission("bvc.disc") }
                             .then(
-                                Commands.argument("audio_id", StringArgumentType.string())
+                                Commands.argument("audio_id", StringArgumentType.greedyString())
                                     .executes { ctx ->
                                         val audioId = StringArgumentType.getString(ctx, "audio_id")
                                         val sender = ctx.source.sender
-                                        if (sender is Player) {
-                                            giveDisc(sender, audioId)
-                                            sender.sendMessage(Component.text("Gave BVC audio disc: $audioId"))
+                                        if (sender !is Player) {
+                                            sender.sendMessage(
+                                                Component.text(
+                                                    "/bvc disc must be run by a player. Use /bvc give <player> <audio_id> from the console."
+                                                )
+                                            )
+                                            return@executes 0
                                         }
+                                        giveDisc(sender, audioId)
+                                        sender.sendMessage(Component.text("Gave BVC audio disc: $audioId"))
                                         Command.SINGLE_SUCCESS
                                     }
                             )
-                    ).build(),
-                "Give a BVC audio disc"
+                    )
+                    .then(
+                        Commands.literal("give")
+                            .requires { it.sender.hasPermission("bvc.disc.give") }
+                            .then(
+                                Commands.argument("target", ArgumentTypes.player())
+                                    .then(
+                                        Commands.argument("audio_id", StringArgumentType.greedyString())
+                                            .executes { ctx ->
+                                                val audioId = StringArgumentType.getString(ctx, "audio_id")
+                                                val resolver = ctx.getArgument(
+                                                    "target", PlayerSelectorArgumentResolver::class.java
+                                                )
+                                                val targets = resolver.resolve(ctx.source)
+                                                if (targets.isEmpty()) {
+                                                    ctx.source.sender.sendMessage(
+                                                        Component.text("No matching player found")
+                                                    )
+                                                    return@executes 0
+                                                }
+                                                for (target in targets) {
+                                                    giveDisc(target, audioId)
+                                                }
+                                                ctx.source.sender.sendMessage(
+                                                    Component.text(
+                                                        "Gave BVC audio disc '$audioId' to ${targets.size} player(s)"
+                                                    )
+                                                )
+                                                Command.SINGLE_SUCCESS
+                                            }
+                                    )
+                            )
+                    )
+                    .build(),
+                "Bedrock Voice Chat commands"
             )
         }
     }
@@ -49,6 +92,7 @@ class DiscCommand(private val plugin: JavaPlugin) {
             meta.persistentDataContainer.set(isBvcDiscKey, PersistentDataType.BOOLEAN, true)
             meta.persistentDataContainer.set(audioIdKey, PersistentDataType.STRING, audioId)
         }
+        disc.unsetData(DataComponentTypes.JUKEBOX_PLAYABLE)
         if (player.inventory.addItem(disc).isNotEmpty()) {
             player.world.dropItem(player.location, disc)
         }

--- a/mods/java/paper/src/main/resources/plugin.yml
+++ b/mods/java/paper/src/main/resources/plugin.yml
@@ -5,3 +5,12 @@ api-version: "1.21"
 description: Server-side player position tracking for proximity voice chat
 authors:
   - Charles R. Portwood II (Alaydriem)
+softdepend:
+  - floodgate
+permissions:
+  bvc.disc:
+    description: Allow getting a BVC audio disc via /bvc disc
+    default: true
+  bvc.disc.give:
+    description: Allow giving BVC audio discs to other players via /bvc give
+    default: op


### PR DESCRIPTION
## Description
1. Fixes an issue where Floodgate mapping for non-linked Floodgate players was not prefixed removed
2. Removed Floodgate prefix config from BVC. BVC now always uses Floodgate's configuration
3. Fixes an issue with PaperMC + Fabric Jukeboxes on eject/playback with multiple bvc disc
4. Fixes an issue where some players can't give themselves a music disc
5. Added CLI command for Paper + Fabric to let operators give a music disc to a specific player
6. Adjusted player cLI to not be operator locked so players can issue their own discs on JAva
7. Address Alignment issue on latest Geyser/Floodgate version

```
bvc give player 019d1877-c165-7e91-bcc9-86b8dc7461a8
```

## Release Notes

For the best experience
1. Bedrock Players _should_ link their Java Identities via Geysers Linking Service
2. Server Operators _should_ by default enable Geyser Linking in Floodgates configuration
```
player-link:
  enabled: true
  require-link: true
```

Unlinked players will be stored in BVC using their Bedrock identity, and BVC server will not facilitate translation mapping whereas previously it did not
3. Java servers Floodgate override has been removed. If floodgate is present, Floodgates config will _always_ be used. It is recommended to _NEVER_ change your prefix mapping if you have existing players
4. Add a note for Java players
- Java players should login with their XBL identity ALWAYS, then link. Server operators may whitelist them prior to connecting.

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).