### PR TITLE
feat: java identity linking at login

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -147,6 +147,14 @@ jobs:
       build_mode: ${{ needs.changes.outputs.build_mode }}
     secrets: inherit
 
+  # Run server + common unit and integration tests
+  test-server:
+    name: Test Server
+    needs: changes
+    if: needs.changes.outputs.server == 'true' || needs.changes.outputs.common == 'true'
+    uses: ./.github/workflows/test-server.yml
+    secrets: inherit
+
   # Build Docker image from server binaries
   build-docker:
     name: Build Docker Image

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,0 +1,61 @@
+name: Test Server
+
+on:
+  pull_request:
+    paths:
+      - 'server/**'
+      - 'common/**'
+      - '.github/workflows/test-server.yml'
+  push:
+    branches:
+      - main
+      - beta
+    paths:
+      - 'server/**'
+      - 'common/**'
+  workflow_call: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test-server:
+    name: cargo test (server + common)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache common crate dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./common"
+          shared-key: common
+
+      - name: Cache server crate dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./server"
+          shared-key: server
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          # libasound2-dev required because common depends on cpal, which links to ALSA on Linux
+          sudo apt-get install -y \
+            pkg-config \
+            cmake \
+            build-essential \
+            libasound2-dev
+
+      - name: Run common crate unit tests
+        working-directory: ./common
+        run: cargo test --lib
+
+      - name: Run server crate unit + integration tests (with test-utils feature)
+        working-directory: ./server/server
+        run: cargo test --features test-utils

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1618,7 @@ dependencies = [
  "ts-rs",
  "typetag",
  "webbrowser",
+ "wiremock",
 ]
 
 [[package]]
@@ -2130,6 +2141,24 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -2906,6 +2935,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -3790,6 +3820,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -11687,6 +11718,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,8 @@
 
 Copyright (c) 2025 - Charles R. Portwood II - All rights reserved
 
+> NOT AN OFFICIAL MINECRAFT SERVICE. NOT APPROVED BY OR ASSOCIATED WITH MOJANG OR MICROSOFT
+
 ---
 
 **PRE-RELEASE NOTICE**

--- a/README.md
+++ b/README.md
@@ -56,5 +56,3 @@ Bedrock Voice Chat has 3 components
 3. And a native client for Windows, iOS, and Android.
 
 All 3 components are mandatory. Be sure to checkout the Wiki for more information: https://github.com/Alaydriem/bedrock-voice-chat/wiki
-
-

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -95,3 +95,6 @@ cpal = { version = "^0.17", optional = true, features = ["asio"] }
 
 [target."cfg(not(target_os = \"windows\"))".dependencies]
 cpal = { version = "^0.17", optional = true }
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/common/src/auth/authenticator.rs
+++ b/common/src/auth/authenticator.rs
@@ -1,0 +1,20 @@
+/// Auth seam for Minecraft OAuth — production uses MinecraftAuthProvider; tests inject fakes.
+use async_trait::async_trait;
+use reqwest::Url;
+
+use super::provider::{AuthError, AuthResult};
+
+#[async_trait]
+pub trait MinecraftAuthenticator: Send + Sync {
+    async fn authenticate(
+        &self,
+        code: String,
+        redirect_uri: Url,
+    ) -> Result<AuthResult, AuthError>;
+
+    async fn authenticate_for_java_profile(
+        &self,
+        code: String,
+        redirect_uri: Url,
+    ) -> Result<String, AuthError>;
+}

--- a/common/src/auth/minecraft/dtos/mod.rs
+++ b/common/src/auth/minecraft/dtos/mod.rs
@@ -2,13 +2,12 @@
 
 mod access_token_response;
 mod minecraft_login_response;
-mod minecraft_profile_response;
 mod profile;
 mod xbox_auth_response;
 
 // Module-internal exports
 pub(super) use access_token_response::AccessTokenResponse;
 pub(super) use minecraft_login_response::MinecraftLoginResponse;
-pub(super) use minecraft_profile_response::MinecraftProfileResponse;
+pub(super) use profile::MinecraftJavaProfile;
 pub(super) use profile::ProfileResponse;
 pub(super) use xbox_auth_response::XboxAuthResponse;

--- a/common/src/auth/minecraft/dtos/profile/mod.rs
+++ b/common/src/auth/minecraft/dtos/profile/mod.rs
@@ -12,3 +12,31 @@ use serde::Deserialize;
 pub(crate) struct ProfileResponse {
     pub profile_users: Vec<ProfileUser>,
 }
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct MinecraftJavaProfile {
+    #[serde(rename = "id")]
+    pub uuid: String,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn java_profile_deserializes_id_and_name() {
+        let body = r#"{"id":"d8d5a92366af4b1d8c6d3e8b5a9b1234","name":"CoolBuilder42"}"#;
+        let profile: MinecraftJavaProfile = serde_json::from_str(body).unwrap();
+        assert_eq!(profile.uuid, "d8d5a92366af4b1d8c6d3e8b5a9b1234");
+        assert_eq!(profile.name, "CoolBuilder42");
+    }
+
+    #[test]
+    fn java_profile_ignores_extra_fields() {
+        let body = r#"{"id":"abc","name":"x","skins":[],"capes":[]}"#;
+        let profile: MinecraftJavaProfile = serde_json::from_str(body).unwrap();
+        assert_eq!(profile.uuid, "abc");
+        assert_eq!(profile.name, "x");
+    }
+}

--- a/common/src/auth/minecraft/mod.rs
+++ b/common/src/auth/minecraft/mod.rs
@@ -14,19 +14,49 @@ use reqwest::Url;
 
 use crate::auth::provider::{AuthError, AuthResult};
 use dtos::{
-    AccessTokenResponse, MinecraftLoginResponse, MinecraftProfileResponse, ProfileResponse,
+    AccessTokenResponse, MinecraftJavaProfile, MinecraftLoginResponse, ProfileResponse,
     XboxAuthResponse,
 };
+
+#[derive(Debug, Clone)]
+pub struct MinecraftAuthEndpoints {
+    pub token_url: String,
+    pub xbl_user_auth_url: String,
+    pub xsts_authorize_url: String,
+    pub user_presence_url: String,
+    pub profile_settings_url: String,
+    pub mc_login_with_xbox_url: String,
+    pub mc_profile_url: String,
+}
+
+impl Default for MinecraftAuthEndpoints {
+    fn default() -> Self {
+        Self {
+            token_url: "https://login.live.com/oauth20_token.srf".into(),
+            xbl_user_auth_url: "https://user.auth.xboxlive.com/user/authenticate".into(),
+            xsts_authorize_url: "https://xsts.auth.xboxlive.com/xsts/authorize".into(),
+            user_presence_url: "https://userpresence.xboxlive.com/users/me".into(),
+            profile_settings_url: "https://profile.xboxlive.com/users/batch/profile/settings".into(),
+            mc_login_with_xbox_url: "https://api.minecraftservices.com/authentication/login_with_xbox".into(),
+            mc_profile_url: "https://api.minecraftservices.com/minecraft/profile".into(),
+        }
+    }
+}
 
 /// Minecraft authentication provider using Xbox Live
 pub struct MinecraftAuthProvider {
     client_id: String,
+    pub(crate) endpoints: MinecraftAuthEndpoints,
 }
 
 impl MinecraftAuthProvider {
-    /// Create a new provider with the given Microsoft OAuth client ID
     pub fn new(client_id: String) -> Self {
-        Self { client_id }
+        Self { client_id, endpoints: MinecraftAuthEndpoints::default() }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoints(client_id: String, endpoints: MinecraftAuthEndpoints) -> Self {
+        Self { client_id, endpoints }
     }
 
     /// Authenticate a user with an OAuth authorization code
@@ -47,30 +77,32 @@ impl MinecraftAuthProvider {
             .build()
             .map_err(|e| AuthError::Network(e.to_string()))?;
 
-        // Step 1: Exchange code for Microsoft access token
         let token = self
             .exchange_code_for_token(&client, &code, &redirect_uri)
             .await?;
 
-        // Step 2: Authenticate with Xbox Live
         let (xbl_token, user_hash) = self.authenticate_xbox_live(&client, &token).await?;
 
-        // Step 3: Get XSTS token
         let xsts_token = self.get_xsts_token(&client, &xbl_token).await?;
 
-        // Step 4: Get user's XUID
-        let xuid = self
-            .get_user_xuid(&client, &user_hash, &xsts_token)
-            .await?;
+        let xuid = self.get_user_xuid(&client, &user_hash, &xsts_token).await?;
 
-        // Step 5: Get user profile (gamertag and gamerpic)
-        let profile = self
-            .get_user_profile(&client, &user_hash, &xsts_token, &xuid)
-            .await?;
+        let xbl_profile_fut = self.get_user_profile(&client, &user_hash, &xsts_token, &xuid);
+        let java_profile_fut = self.get_minecraft_java_profile(&client, &user_hash, &xbl_token);
 
-        let minecraft_username: Option<String> = None;
+        let (xbl_result, java_result) = tokio::join!(xbl_profile_fut, java_profile_fut);
 
-        Ok(profile.with_minecraft_username(minecraft_username))
+        let profile = xbl_result?;
+
+        let (minecraft_username, minecraft_uuid) = match java_result {
+            Ok(p) => (Some(p.name), Some(p.uuid)),
+            Err(e) => {
+                tracing::info!("Java profile not available (account likely lacks Java license): {}", e);
+                (None, None)
+            }
+        };
+
+        Ok(profile.with_java_profile(minecraft_username, minecraft_uuid))
     }
 }
 
@@ -95,6 +127,7 @@ impl MinecraftAuthProvider {
 
         self.get_minecraft_java_profile(&client, &user_hash, &xbl_token)
             .await
+            .map(|p| p.name)
     }
 
     async fn exchange_code_for_token(
@@ -104,7 +137,7 @@ impl MinecraftAuthProvider {
         redirect_uri: &Url,
     ) -> Result<String, AuthError> {
         let response = client
-            .post("https://login.live.com/oauth20_token.srf")
+            .post(&self.endpoints.token_url)
             .form(&[
                 ("client_id", self.client_id.clone()),
                 ("code", code.to_string()),
@@ -148,7 +181,7 @@ impl MinecraftAuthProvider {
         });
 
         let response: XboxAuthResponse = client
-            .post("https://user.auth.xboxlive.com/user/authenticate")
+            .post(&self.endpoints.xbl_user_auth_url)
             .json(&json)
             .send()
             .await?
@@ -187,7 +220,7 @@ impl MinecraftAuthProvider {
         headers.insert("x-xbl-contract-version", "1".parse().unwrap());
 
         let response: XboxAuthResponse = client
-            .post("https://xsts.auth.xboxlive.com/xsts/authorize")
+            .post(&self.endpoints.xsts_authorize_url)
             .json(&json)
             .headers(headers)
             .send()
@@ -218,7 +251,7 @@ impl MinecraftAuthProvider {
         headers.insert("Host", "userpresence.xboxlive.com".parse().unwrap());
 
         let presence: serde_json::Value = client
-            .get("https://userpresence.xboxlive.com/users/me")
+            .get(&self.endpoints.user_presence_url)
             .headers(headers)
             .send()
             .await?
@@ -249,7 +282,7 @@ impl MinecraftAuthProvider {
         headers.insert("x-xbl-contract-version", "3".parse().unwrap());
 
         let profile: ProfileResponse = client
-            .post("https://profile.xboxlive.com/users/batch/profile/settings")
+            .post(&self.endpoints.profile_settings_url)
             .json(&serde_json::json!({
                 "userIds": vec![xuid],
                 "settings": vec![
@@ -293,14 +326,12 @@ impl MinecraftAuthProvider {
         }
     }
 
-    /// Get the player's Minecraft Java Edition profile (username + UUID).
-    /// Returns None if the player doesn't own Java Edition.
     async fn get_minecraft_java_profile(
         &self,
         client: &reqwest::Client,
         user_hash: &str,
         xbl_token: &str,
-    ) -> Result<String, AuthError> {
+    ) -> Result<MinecraftJavaProfile, AuthError> {
         // Get a separate XSTS token for Minecraft Services
         let mc_xsts_token = self
             .get_minecraft_xsts_token(client, xbl_token)
@@ -314,7 +345,7 @@ impl MinecraftAuthProvider {
         let identity_token = format!("XBL3.0 x={};{}", user_hash, mc_xsts_token);
 
         let mc_login_response = client
-            .post("https://api.minecraftservices.com/authentication/login_with_xbox")
+            .post(&self.endpoints.mc_login_with_xbox_url)
             .json(&serde_json::json!({
                 "identityToken": identity_token,
             }))
@@ -340,7 +371,7 @@ impl MinecraftAuthProvider {
         // Fetch the Minecraft profile
         tracing::info!("MC Services: Fetching Minecraft profile");
         let profile_response = client
-            .get("https://api.minecraftservices.com/minecraft/profile")
+            .get(&self.endpoints.mc_profile_url)
             .header("Authorization", format!("Bearer {}", mc_login.access_token))
             .send()
             .await?;
@@ -355,12 +386,12 @@ impl MinecraftAuthProvider {
             )));
         }
 
-        let profile: MinecraftProfileResponse = profile_response
+        let profile: MinecraftJavaProfile = profile_response
             .json()
             .await
             .map_err(|e| AuthError::InvalidResponse(e.to_string()))?;
 
-        Ok(profile.name)
+        Ok(profile)
     }
 
     /// Get an XSTS token authorized for Minecraft Services
@@ -383,7 +414,7 @@ impl MinecraftAuthProvider {
         headers.insert("Content-Type", "application/json".parse().unwrap());
 
         let xsts_response = client
-            .post("https://xsts.auth.xboxlive.com/xsts/authorize")
+            .post(&self.endpoints.xsts_authorize_url)
             .json(&json)
             .headers(headers)
             .send()
@@ -405,5 +436,211 @@ impl MinecraftAuthProvider {
             .map_err(|e| AuthError::InvalidResponse(e.to_string()))?;
 
         Ok(response.token)
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::auth::MinecraftAuthenticator for MinecraftAuthProvider {
+    async fn authenticate(
+        &self,
+        code: String,
+        redirect_uri: reqwest::Url,
+    ) -> Result<crate::auth::AuthResult, crate::auth::AuthError> {
+        MinecraftAuthProvider::authenticate(self, code, redirect_uri).await
+    }
+
+    async fn authenticate_for_java_profile(
+        &self,
+        code: String,
+        redirect_uri: reqwest::Url,
+    ) -> Result<String, crate::auth::AuthError> {
+        MinecraftAuthProvider::authenticate_for_java_profile(self, code, redirect_uri).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoints_default_uses_production_urls() {
+        let e = MinecraftAuthEndpoints::default();
+        assert_eq!(e.token_url, "https://login.live.com/oauth20_token.srf");
+        assert_eq!(e.xbl_user_auth_url, "https://user.auth.xboxlive.com/user/authenticate");
+        assert_eq!(e.xsts_authorize_url, "https://xsts.auth.xboxlive.com/xsts/authorize");
+        assert_eq!(e.user_presence_url, "https://userpresence.xboxlive.com/users/me");
+        assert_eq!(e.profile_settings_url, "https://profile.xboxlive.com/users/batch/profile/settings");
+        assert_eq!(e.mc_login_with_xbox_url, "https://api.minecraftservices.com/authentication/login_with_xbox");
+        assert_eq!(e.mc_profile_url, "https://api.minecraftservices.com/minecraft/profile");
+    }
+
+    #[test]
+    fn provider_default_constructor_uses_production_endpoints() {
+        let p = MinecraftAuthProvider::new("client-id".into());
+        assert!(p.endpoints.token_url.starts_with("https://login.live.com"));
+    }
+
+    async fn mount_xbl_mocks(server: &wiremock::MockServer) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        Mock::given(method("POST")).and(path("/oauth20_token.srf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "ms-token",
+                "expires_in": 3600,
+                "refresh_token": "rt",
+                "token_type": "bearer"
+            })))
+            .mount(server).await;
+
+        Mock::given(method("POST")).and(path("/user/authenticate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Token": "xbl-token",
+                "DisplayClaims": { "xui": [{ "uhs": "user-hash" }] }
+            })))
+            .mount(server).await;
+
+        Mock::given(method("POST")).and(path("/xsts/authorize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Token": "xsts-token",
+                "DisplayClaims": { "xui": [{ "uhs": "user-hash" }] }
+            })))
+            .mount(server).await;
+
+        Mock::given(method("GET")).and(path("/users/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "xuid": "1234567890"
+            })))
+            .mount(server).await;
+
+        Mock::given(method("POST")).and(path("/users/batch/profile/settings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "profileUsers": [{
+                    "id": "1234567890",
+                    "settings": [
+                        { "id": "Gamertag", "value": "AwesomeXboxer123" },
+                        { "id": "GameDisplayPicRaw", "value": "" }
+                    ]
+                }]
+            })))
+            .mount(server).await;
+    }
+
+    #[tokio::test]
+    async fn authenticate_happy_path_returns_gamertag_and_gamerpic() {
+        use wiremock::MockServer;
+
+        let server = MockServer::start().await;
+        mount_xbl_mocks(&server).await;
+
+        let endpoints = MinecraftAuthEndpoints {
+            token_url: format!("{}/oauth20_token.srf", server.uri()),
+            xbl_user_auth_url: format!("{}/user/authenticate", server.uri()),
+            xsts_authorize_url: format!("{}/xsts/authorize", server.uri()),
+            user_presence_url: format!("{}/users/me", server.uri()),
+            profile_settings_url: format!("{}/users/batch/profile/settings", server.uri()),
+            mc_login_with_xbox_url: format!("{}/authentication/login_with_xbox", server.uri()),
+            mc_profile_url: format!("{}/minecraft/profile", server.uri()),
+        };
+
+        let provider = MinecraftAuthProvider::with_endpoints("cid".into(), endpoints);
+
+        let result = provider
+            .authenticate("auth-code".into(), "http://app/cb".parse().unwrap())
+            .await
+            .expect("authenticate ok");
+
+        assert_eq!(result.gamertag, "AwesomeXboxer123");
+        assert!(result.minecraft_username.is_none());
+        assert!(result.minecraft_uuid.is_none());
+    }
+
+    #[tokio::test]
+    async fn authenticate_returns_java_profile_when_present() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        mount_xbl_mocks(&server).await;
+
+        Mock::given(method("POST")).and(path("/authentication/login_with_xbox"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "mc-access"
+            })))
+            .mount(&server).await;
+
+        Mock::given(method("GET")).and(path("/minecraft/profile"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "java-uuid-1", "name": "CoolBuilder42"
+            })))
+            .mount(&server).await;
+
+        let endpoints = MinecraftAuthEndpoints {
+            token_url: format!("{}/oauth20_token.srf", server.uri()),
+            xbl_user_auth_url: format!("{}/user/authenticate", server.uri()),
+            xsts_authorize_url: format!("{}/xsts/authorize", server.uri()),
+            user_presence_url: format!("{}/users/me", server.uri()),
+            profile_settings_url: format!("{}/users/batch/profile/settings", server.uri()),
+            mc_login_with_xbox_url: format!("{}/authentication/login_with_xbox", server.uri()),
+            mc_profile_url: format!("{}/minecraft/profile", server.uri()),
+        };
+
+        let provider = MinecraftAuthProvider::with_endpoints("cid".into(), endpoints);
+
+        let result = provider
+            .authenticate("auth-code".into(), "http://app/cb".parse().unwrap())
+            .await
+            .expect("authenticate ok");
+
+        assert_eq!(result.gamertag, "AwesomeXboxer123");
+        assert_eq!(result.minecraft_username.as_deref(), Some("CoolBuilder42"));
+        assert_eq!(result.minecraft_uuid.as_deref(), Some("java-uuid-1"));
+    }
+
+    #[test]
+    fn minecraft_auth_provider_is_object_safe() {
+        fn assert_object_safe(_: &dyn crate::auth::MinecraftAuthenticator) {}
+        let p = MinecraftAuthProvider::new("cid".into());
+        assert_object_safe(&p);
+    }
+
+    #[tokio::test]
+    async fn authenticate_handles_no_java_license() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        mount_xbl_mocks(&server).await;
+
+        Mock::given(method("POST")).and(path("/authentication/login_with_xbox"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "mc-access"
+            })))
+            .mount(&server).await;
+
+        Mock::given(method("GET")).and(path("/minecraft/profile"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server).await;
+
+        let endpoints = MinecraftAuthEndpoints {
+            token_url: format!("{}/oauth20_token.srf", server.uri()),
+            xbl_user_auth_url: format!("{}/user/authenticate", server.uri()),
+            xsts_authorize_url: format!("{}/xsts/authorize", server.uri()),
+            user_presence_url: format!("{}/users/me", server.uri()),
+            profile_settings_url: format!("{}/users/batch/profile/settings", server.uri()),
+            mc_login_with_xbox_url: format!("{}/authentication/login_with_xbox", server.uri()),
+            mc_profile_url: format!("{}/minecraft/profile", server.uri()),
+        };
+
+        let provider = MinecraftAuthProvider::with_endpoints("cid".into(), endpoints);
+
+        let result = provider
+            .authenticate("auth-code".into(), "http://app/cb".parse().unwrap())
+            .await
+            .expect("authenticate ok");
+
+        assert_eq!(result.gamertag, "AwesomeXboxer123");
+        assert!(result.minecraft_username.is_none());
+        assert!(result.minecraft_uuid.is_none());
     }
 }

--- a/common/src/auth/mod.rs
+++ b/common/src/auth/mod.rs
@@ -36,10 +36,12 @@
 //! }
 //! ```
 
+mod authenticator;
 mod hytale;
 mod minecraft;
 mod provider;
 
 pub use provider::{AuthError, AuthResult};
 pub use minecraft::MinecraftAuthProvider;
+pub use authenticator::MinecraftAuthenticator;
 pub use hytale::{DeviceFlow, HytaleAuthProvider, PollResult};

--- a/common/src/auth/provider/dtos/auth_result.rs
+++ b/common/src/auth/provider/dtos/auth_result.rs
@@ -10,6 +10,8 @@ pub struct AuthResult {
     /// The user's Minecraft Java username (if they own Java Edition)
     #[serde(default)]
     pub minecraft_username: Option<String>,
+    #[serde(default)]
+    pub minecraft_uuid: Option<String>,
 }
 
 impl AuthResult {
@@ -19,6 +21,7 @@ impl AuthResult {
             gamertag,
             gamerpic,
             minecraft_username: None,
+            minecraft_uuid: None,
         }
     }
 
@@ -28,6 +31,7 @@ impl AuthResult {
             gamertag,
             gamerpic: String::new(),
             minecraft_username: None,
+            minecraft_uuid: None,
         }
     }
 
@@ -35,5 +39,44 @@ impl AuthResult {
     pub fn with_minecraft_username(mut self, username: Option<String>) -> Self {
         self.minecraft_username = username;
         self
+    }
+
+    pub fn with_java_profile(
+        mut self,
+        username: Option<String>,
+        uuid: Option<String>,
+    ) -> Self {
+        self.minecraft_username = username;
+        self.minecraft_uuid = uuid;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_java_profile_sets_both_fields() {
+        let r = AuthResult::new("Tag".into(), "pic".into())
+            .with_java_profile(Some("JavaName".into()), Some("uuid-1".into()));
+        assert_eq!(r.minecraft_username.as_deref(), Some("JavaName"));
+        assert_eq!(r.minecraft_uuid.as_deref(), Some("uuid-1"));
+    }
+
+    #[test]
+    fn with_java_profile_accepts_none() {
+        let r = AuthResult::new("Tag".into(), "pic".into())
+            .with_java_profile(None, None);
+        assert!(r.minecraft_username.is_none());
+        assert!(r.minecraft_uuid.is_none());
+    }
+
+    #[test]
+    fn auth_result_serializes_uuid_when_present() {
+        let r = AuthResult::new("Tag".into(), "pic".into())
+            .with_java_profile(Some("J".into()), Some("u".into()));
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains(r#""minecraft_uuid":"u""#));
     }
 }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -447,6 +447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +686,7 @@ dependencies = [
  "ogg",
  "okapi",
  "opus2",
+ "parking_lot",
  "proc_mem",
  "rand 0.10.0",
  "rcgen",
@@ -705,6 +716,7 @@ dependencies = [
  "uuid",
  "windows 0.62.2",
  "windows-targets 0.53.5",
+ "wiremock",
 ]
 
 [[package]]
@@ -1507,6 +1519,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deadqueue"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +1972,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2483,6 +2514,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -7432,6 +7464,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -16,10 +16,16 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 name = "bvc-server"
 path = "src/main.rs"
 
+[[test]]
+name = "identity_link"
+path = "tests/identity_link.rs"
+required-features = ["test-utils"]
+
 [features]
 default = []
 ffi = []
 bundled-sqlite = []
+test-utils = []
 
 [dependencies]
 common = { path = "../../common", features = ["quic", "templates", "server"] }
@@ -97,6 +103,9 @@ ringbuf = { version = "0.4" }
 hound = "^3.5"
 read-process-memory = "0.1.6"
 proc_mem = "0.1.6"
+wiremock = "0.6"
+parking_lot = "0.12"
+sea-orm = { workspace = true, features = ["mock"] }
 
 [target.'cfg(target_env = "musl")'.dependencies]
 libsqlite3-sys = { version = "^0.30", features = ["bundled"] }

--- a/server/server/examples/http_client.rs
+++ b/server/server/examples/http_client.rs
@@ -106,11 +106,7 @@ async fn main() -> anyhow::Result<()> {
     c = c.headers(headers);
     match opt.data.clone() {
         Some(data) => {
-            c = c.json(
-                &(ChannelEvent {
-                    event: ChannelEvents::Leave,
-                }),
-            );
+            c = c.json(&ChannelEvent::new(ChannelEvents::Leave));
         }
         None => {}
     }

--- a/server/server/src/ffi/mod.rs
+++ b/server/server/src/ffi/mod.rs
@@ -463,6 +463,10 @@ pub unsafe extern "C" fn bvc_update_positions(
             }
 
             id_service
+                .resolve_uuid_and_remap_players(&mut players, &game_type)
+                .await;
+
+            id_service
                 .resolve_and_remap_players(&mut players, &game_type)
                 .await;
         }

--- a/server/server/src/http/guards/mc_access_token.rs
+++ b/server/server/src/http/guards/mc_access_token.rs
@@ -23,6 +23,10 @@ impl<'r> FromRequest<'r> for MCAccessToken {
     type Error = MCAccessTokenError;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        #[cfg(any(test, feature = "test-utils"))]
+        if req.headers().get_one("X-MC-Access-Token") == Some("test-bypass-token") {
+            return Outcome::Success(MCAccessToken("test-bypass-token".into()));
+        }
         return match req.headers().get_one("X-MC-Access-Token") {
             Some(key) => {
                 let at = req

--- a/server/server/src/http/manager/mod.rs
+++ b/server/server/src/http/manager/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     services::{AudioPlaybackService, AudioStreamTokenCache, CertificateService, PlayerIdentityService, PlayerRegistrarService},
     stream::quic::{CacheManager, WebhookReceiver},
 };
+use common::auth::{MinecraftAuthProvider, MinecraftAuthenticator};
 use anyhow::Error;
 use common::ncryptflib as ncryptf;
 use migration::{Migrator, MigratorTrait};
@@ -85,6 +86,11 @@ impl RocketManager {
                     )
                     .allow_credentials(true);
 
+                let mc_authenticator: std::sync::Arc<dyn MinecraftAuthenticator> =
+                    std::sync::Arc::new(MinecraftAuthProvider::new(
+                        self.config.server.minecraft.client_id.clone(),
+                    ));
+
                 let mut rocket = rocket::custom(figment)
                     .manage(cache_wrapper)
                     .manage(self.config.server.clone())
@@ -96,6 +102,7 @@ impl RocketManager {
                     .manage(self.identity_service.clone())
                     .manage(self.audio_playback_service.clone())
                     .manage(self.cert_service.clone())
+                    .manage(mc_authenticator)
                     .manage(self.config.permissions.clone())
                     .manage(self.config.audio.clone())
                     .manage(self.hytale_session_cache.clone())

--- a/server/server/src/http/routes/api/auth/link_java.rs
+++ b/server/server/src/http/routes/api/auth/link_java.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use common::{
-    auth::MinecraftAuthProvider,
+    auth::MinecraftAuthenticator,
     request::LinkJavaIdentityRequest,
     response::LinkJavaIdentityResponse,
     Game,
@@ -15,6 +17,7 @@ pub async fn link_java_identity(
     _identity: Certificate<'_>,
     payload: Json<LinkJavaIdentityRequest>,
     identity_service: &State<PlayerIdentityService>,
+    authenticator: &State<Arc<dyn MinecraftAuthenticator>>,
 ) -> Result<Json<LinkJavaIdentityResponse>, Status> {
     let request = payload.0;
 
@@ -23,10 +26,7 @@ pub async fn link_java_identity(
         .parse()
         .map_err(|_| Status::BadRequest)?;
 
-    let provider = MinecraftAuthProvider::new(request.client_id);
-
-    // Only fetch the MC Java profile — skip full Xbox profile lookup
-    let mc_username = provider
+    let mc_username = authenticator
         .authenticate_for_java_profile(request.code, redirect_uri)
         .await
         .map_err(|e| {

--- a/server/server/src/http/routes/api/auth/minecraft.rs
+++ b/server/server/src/http/routes/api/auth/minecraft.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use common::{
-    auth::{AuthError as CommonAuthError, MinecraftAuthProvider},
+    auth::{AuthError as CommonAuthError, MinecraftAuthenticator},
     request::LoginRequest,
     response::LoginResponse,
     Game,
@@ -13,7 +13,7 @@ use crate::config::{Permissions, Server};
 use crate::http::dtos::ncryptf::JsonMessage;
 use crate::http::openapi::NcryptfJsonResponse;
 use crate::http::pool::Db;
-use crate::services::{AuthError, AuthService, CertificateService, PermissionService, PlayerIdentityService};
+use crate::services::{AuthError, AuthService, CertificateService, PermissionService, PlayerIdentityService, PlayerRegistrarService};
 
 /// Authenticates the Player via Xbox Live to grab their gamertag and other identifying information
 #[openapi(tag = "Authentication")]
@@ -24,7 +24,9 @@ pub async fn authenticate(
     config: &State<Server>,
     cert_service: &State<Arc<CertificateService>>,
     identity_service: &State<PlayerIdentityService>,
+    player_registrar: &State<PlayerRegistrarService>,
     perm_config: &State<Permissions>,
+    authenticator: &State<Arc<dyn MinecraftAuthenticator>>,
 ) -> NcryptfJsonResponse<LoginResponse> {
     let conn = db.into_inner();
 
@@ -37,11 +39,7 @@ pub async fn authenticate(
         }
     };
 
-    // Create the Minecraft auth provider
-    let provider = MinecraftAuthProvider::new(config.minecraft.client_id.clone());
-
-    // Authenticate with Xbox Live
-    let auth_result = match provider.authenticate(code, redirect_uri).await {
+    let auth_result = match authenticator.authenticate(code, redirect_uri).await {
         Ok(result) => result,
         Err(e) => {
             tracing::error!("Xbox Live authentication failed: {}", e);
@@ -56,8 +54,28 @@ pub async fn authenticate(
 
     let gamertag = auth_result.gamertag.clone();
     let minecraft_username = auth_result.minecraft_username.clone();
+    let mc_uuid = auth_result.minecraft_uuid.clone();
 
-    // Build login response using AuthService
+    let xbl_player_id = identity_service
+        .find_player_id_by_gamertag(&gamertag, &Game::Minecraft)
+        .await;
+
+    let uuid_player_id = match mc_uuid.as_deref() {
+        Some(uuid) => {
+            identity_service
+                .find_player_id_by_alias(uuid, "platform_uuid", &Game::Minecraft)
+                .await
+        }
+        None => None,
+    };
+
+    // Phase B re-mapping: create XBL record when Java UUID alias resolves
+    if xbl_player_id.is_none() && uuid_player_id.is_some() {
+        player_registrar
+            .create_player(&gamertag, &Game::Minecraft, None)
+            .await;
+    }
+
     let perm_service = PermissionService::new(perm_config.defaults.clone());
     match AuthService::build_login_response(
         conn,
@@ -71,25 +89,38 @@ pub async fn authenticate(
     .await
     {
         Ok(mut response) => {
-            // Store the MC Java username alias if it differs from the gamertag
-            if let Some(ref mc_name) = minecraft_username {
-                if mc_name != &gamertag {
-                    if let Some(player_id) = identity_service
-                        .find_player_id_by_gamertag(&gamertag, &Game::Minecraft)
-                        .await
-                    {
+            if minecraft_username.is_some() || mc_uuid.is_some() {
+                if let Some(player_id) = identity_service
+                    .find_player_id_by_gamertag(&gamertag, &Game::Minecraft)
+                    .await
+                {
+                    if let Some(ref mc_name) = minecraft_username {
+                        if mc_name != &gamertag {
+                            if let Err(e) = identity_service
+                                .create_alias(
+                                    player_id,
+                                    mc_name,
+                                    &Game::Minecraft,
+                                    "minecraft_services",
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    "Failed to create minecraft_services alias for {}: {}",
+                                    mc_name,
+                                    e
+                                );
+                            }
+                        }
+                    }
+                    if let Some(ref uuid) = mc_uuid {
                         if let Err(e) = identity_service
-                            .create_alias(
-                                player_id,
-                                mc_name,
-                                &Game::Minecraft,
-                                "minecraft_services",
-                            )
+                            .create_alias(player_id, uuid, &Game::Minecraft, "platform_uuid")
                             .await
                         {
                             tracing::warn!(
-                                "Failed to create identity alias for {}: {}",
-                                mc_name,
+                                "Failed to create platform_uuid alias for {}: {}",
+                                uuid,
                                 e
                             );
                         }
@@ -97,7 +128,6 @@ pub async fn authenticate(
                 }
             }
 
-            // Include MC username in response for client display
             response.minecraft_username = minecraft_username;
 
             NcryptfJsonResponse::from_inner(JsonMessage::create(Status::Ok, Some(response), None, None))

--- a/server/server/src/http/routes/api/positions/mod.rs
+++ b/server/server/src/http/routes/api/positions/mod.rs
@@ -59,6 +59,10 @@ pub async fn update_position(
     }
 
     identity_service
+        .resolve_uuid_and_remap_players(&mut all_players, &game_type)
+        .await;
+
+    identity_service
         .resolve_and_remap_players(&mut all_players, &game_type)
         .await;
 

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -16,6 +16,80 @@ pub mod runtime;
 pub use config::ApplicationConfig;
 pub use runtime::{RuntimeState, ServerRuntime};
 
+/// Build a minimal Rocket instance suitable for integration tests.
+///
+/// Mounts only the `/api/auth/minecraft` route and wires the state it needs.
+/// Gated behind `cfg(feature = "test-utils")` so it is never compiled into
+/// production binaries.
+#[cfg(feature = "test-utils")]
+pub async fn build_test_rocket(
+    authenticator: std::sync::Arc<dyn common::auth::MinecraftAuthenticator>,
+    db_url: String,
+) -> rocket::Rocket<rocket::Build> {
+    use std::sync::Arc;
+    use rocket::figment::Figment;
+    use sea_orm_rocket::Database as _;
+    use common::ncryptflib::randombytes_buf;
+
+    let cert_service = Arc::new(
+        services::CertificateService::new_for_test()
+            .expect("test CA generation"),
+    );
+
+    let certs_dir = std::env::temp_dir().join(format!("bvc_test_certs_{}", std::process::id()));
+    std::fs::create_dir_all(&certs_dir).expect("create temp certs dir");
+    std::fs::write(certs_dir.join("ca.crt"), cert_service.ca_cert_pem())
+        .expect("write test CA cert");
+
+    let mut server_config = config::Server::default();
+    server_config.tls.certs_path = certs_dir.to_string_lossy().into_owned();
+
+    let permissions = config::Permissions::default();
+    let identity_db = Arc::new(
+        sea_orm::Database::connect(&db_url)
+            .await
+            .expect("identity service db"),
+    );
+    let identity_service = services::PlayerIdentityService::new(identity_db.clone());
+    let player_registrar = services::PlayerRegistrarService::new(identity_db, cert_service.clone());
+
+    let (webhook_tx, _webhook_rx) = tokio::sync::mpsc::unbounded_channel();
+    let webhook_receiver = stream::quic::WebhookReceiver::new(webhook_tx);
+
+    let figment = Figment::from(rocket::Config::default())
+        .merge(("log_level", rocket::config::LogLevel::Off))
+        .merge(("secret_key", randombytes_buf(32)))
+        .merge((
+            "databases.app",
+            sea_orm_rocket::Config {
+                url: db_url,
+                min_connections: None,
+                max_connections: 4,
+                connect_timeout: 3,
+                idle_timeout: None,
+                sqlx_logging: false,
+            },
+        ));
+
+    rocket::custom(figment)
+        .manage(server_config)
+        .manage(permissions)
+        .manage(cert_service)
+        .manage(identity_service)
+        .manage(player_registrar)
+        .manage(webhook_receiver)
+        .manage(authenticator)
+        .attach(http::pool::AppDb::init())
+        .mount(
+            "/api",
+            rocket::routes![
+                http::routes::api::auth::minecraft::authenticate,
+                http::routes::api::auth::link_java::link_java_identity,
+                http::routes::api::positions::update_position,
+            ],
+        )
+}
+
 mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }

--- a/server/server/src/services/certificate_service/mod.rs
+++ b/server/server/src/services/certificate_service/mod.rs
@@ -81,6 +81,29 @@ impl CertificateService {
         }
     }
 
+    /// Return the CA certificate PEM for use in tests.
+    #[cfg(feature = "test-utils")]
+    pub fn ca_cert_pem(&self) -> String {
+        self.root_certificate.pem()
+    }
+
+    /// Create a CertificateService backed by an in-memory self-signed CA for use in tests.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn new_for_test() -> Result<Self, anyhow::Error> {
+        use rcgen::{BasicConstraints, IsCa};
+
+        let root_kp = KeyPair::generate()?;
+
+        let mut params = CertificateParams::default();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let root_cert = params.self_signed(&root_kp)?;
+
+        Ok(Self {
+            root_certificate: root_cert,
+            root_keypair: root_kp,
+        })
+    }
+
     /// Load the root CA certificate and keypair from disk.
     fn load_root_ca(certificate_path: &str) -> Result<(Certificate, KeyPair), anyhow::Error> {
         let root_ca_path_str = format!("{}/{}", certificate_path, "ca.crt");

--- a/server/server/src/services/player_identity_service/mod.rs
+++ b/server/server/src/services/player_identity_service/mod.rs
@@ -61,6 +61,37 @@ impl PlayerIdentityService {
         in_game_name.to_string()
     }
 
+    /// Resolve players by platform UUID alias before the name-based pass.
+    /// If a `platform_uuid` alias exists for the player's UUID, remaps the player's
+    /// name to the canonical gamertag and records the current Java username as a
+    /// `minecraft_services` alias if it has drifted.
+    pub async fn resolve_uuid_and_remap_players(
+        &self,
+        players: &mut Vec<common::PlayerEnum>,
+        game: &Game,
+    ) {
+        for player in players.iter_mut() {
+            let uuid = match player.get_player_uuid() {
+                Some(u) => u.to_string(),
+                None => continue,
+            };
+            if uuid.is_empty() {
+                continue;
+            }
+            if let Some(player_id) = self.find_player_id_by_alias(&uuid, "platform_uuid", game).await {
+                if let Some(canonical) = self.lookup_gamertag(player_id, game).await {
+                    let current_name = player.get_name().to_string();
+                    if canonical != current_name {
+                        let _ = self
+                            .create_alias(player_id, &current_name, game, "minecraft_services")
+                            .await;
+                        player.set_name(canonical);
+                    }
+                }
+            }
+        }
+    }
+
     /// Bulk resolve in-game names to canonical gamertags, mutating player names in place.
     pub async fn resolve_and_remap_players(
         &self,
@@ -156,6 +187,28 @@ impl PlayerIdentityService {
         }
     }
 
+    pub async fn find_player_id_by_alias(
+        &self,
+        alias: &str,
+        alias_type: &str,
+        game: &Game,
+    ) -> Option<i32> {
+        match player_identity::Entity::find()
+            .filter(player_identity::Column::Alias.eq(alias))
+            .filter(player_identity::Column::AliasType.eq(alias_type))
+            .filter(player_identity::Column::Game.eq(game.clone()))
+            .one(self.db.as_ref())
+            .await
+        {
+            Ok(Some(record)) => Some(record.player_id),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::error!("Failed to find player_id by alias: {}", e);
+                None
+            }
+        }
+    }
+
     /// Look up a gamertag by player ID.
     async fn lookup_gamertag(&self, player_id: i32, game: &Game) -> Option<String> {
         match player::Entity::find_by_id(player_id)
@@ -175,6 +228,10 @@ impl PlayerIdentityService {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
     use super::*;
 
     #[test]
@@ -185,5 +242,39 @@ mod tests {
 
         let key3 = ("CoolBuilder42".to_string(), Game::Hytale);
         assert_ne!(key1, key3);
+    }
+
+    #[tokio::test]
+    async fn find_player_id_by_alias_returns_some_when_match() {
+        let db = MockDatabase::new(DatabaseBackend::Sqlite)
+            .append_query_results([vec![player_identity::Model {
+                id: 1,
+                player_id: 42,
+                alias: "uuid-1".into(),
+                game: Game::Minecraft,
+                alias_type: "platform_uuid".into(),
+                created_at: 0,
+                updated_at: 0,
+            }]])
+            .into_connection();
+
+        let svc = PlayerIdentityService::new(Arc::new(db));
+        let id = svc
+            .find_player_id_by_alias("uuid-1", "platform_uuid", &Game::Minecraft)
+            .await;
+        assert_eq!(id, Some(42));
+    }
+
+    #[tokio::test]
+    async fn find_player_id_by_alias_returns_none_on_miss() {
+        let db = MockDatabase::new(DatabaseBackend::Sqlite)
+            .append_query_results([Vec::<player_identity::Model>::new()])
+            .into_connection();
+
+        let svc = PlayerIdentityService::new(Arc::new(db));
+        let id = svc
+            .find_player_id_by_alias("missing", "platform_uuid", &Game::Minecraft)
+            .await;
+        assert!(id.is_none());
     }
 }

--- a/server/server/tests/identity_link.rs
+++ b/server/server/tests/identity_link.rs
@@ -1,0 +1,674 @@
+mod support;
+
+fn minecraft_position_body(
+    name: &str,
+    player_uuid: Option<&str>,
+    alternative_identity: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "game": "minecraft",
+        "players": [{
+            "name": name,
+            "coordinates": { "x": 0.0, "y": 64.0, "z": 0.0 },
+            "orientation": { "x": 0.0, "y": 0.0 },
+            "dimension": "overworld",
+            "deafen": false,
+            "spectator": false,
+            "world_uuid": "world-1",
+            "alternative_identity": alternative_identity,
+            "player_uuid": player_uuid
+        }]
+    })
+}
+
+#[tokio::test]
+async fn a1_java_first_auto_register_writes_uuid_alias() {
+    use common::Game;
+    use entity::{player, player_identity};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+        common::auth::AuthError::AuthenticationFailed("unused".into()),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let body = minecraft_position_body("CoolBuilder42", Some("java-uuid-1"), None);
+    let resp = client
+        .post("/api/position")
+        .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(players.len(), 1);
+    assert_eq!(players[0].gamertag.as_deref(), Some("CoolBuilder42"));
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(players[0].id))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert!(
+        aliases
+            .iter()
+            .any(|a| a.alias == "java-uuid-1" && a.alias_type == "platform_uuid"),
+        "expected platform_uuid alias for java-uuid-1"
+    );
+}
+
+#[tokio::test]
+async fn a2_uuid_alias_refreshes_minecraft_services_alias_on_rename() {
+    use common::Game;
+    use entity::{player, player_identity};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+        common::auth::AuthError::AuthenticationFailed("unused".into()),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "OldName", "minecraft_services", &Game::Minecraft).await;
+
+    let body = minecraft_position_body("NewName", Some("java-uuid-1"), None);
+    let resp = client
+        .post("/api/position")
+        .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(
+        players.len(),
+        1,
+        "no new player should be created (UUID resolves to existing XBL record)"
+    );
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(xbl_id))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    let names: std::collections::HashSet<_> = aliases
+        .iter()
+        .filter(|a| a.alias_type == "minecraft_services")
+        .map(|a| a.alias.clone())
+        .collect();
+    assert!(
+        names.contains("NewName"),
+        "new java name should be aliased after rename; found: {:?}",
+        names
+    );
+}
+
+#[tokio::test]
+async fn a3_uuid_alias_remaps_to_xbl_record() {
+    use common::Game;
+    use entity::player;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+        common::auth::AuthError::AuthenticationFailed("unused".into()),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+
+    let body = minecraft_position_body("CoolBuilder42", Some("java-uuid-1"), None);
+    let resp = client
+        .post("/api/position")
+        .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(players.len(), 1, "no new player should be created");
+    assert_eq!(
+        players[0].gamertag.as_deref(),
+        Some("AwesomeXboxer123"),
+        "player should be the XBL record"
+    );
+}
+
+#[tokio::test]
+async fn a4_floodgate_alternative_identity_still_creates_alias() {
+    use common::Game;
+    use entity::player_identity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+        common::auth::AuthError::AuthenticationFailed("unused".into()),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let xbl_id = support::seed_player(&db.conn, "BedrockTag", &Game::Minecraft).await;
+
+    let body = minecraft_position_body(".BedrockTag", None, Some("BedrockTag"));
+    let resp = client
+        .post("/api/position")
+        .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(xbl_id))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert!(
+        aliases
+            .iter()
+            .any(|a| a.alias == ".BedrockTag" && a.alias_type == "floodgate"),
+        "expected floodgate alias for .BedrockTag; found: {:?}",
+        aliases.iter().map(|a| (&a.alias, &a.alias_type)).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn a5_uuid_shadows_orphan_gamertag_lookup() {
+    use common::Game;
+    use entity::player;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+        common::auth::AuthError::AuthenticationFailed("unused".into()),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let orphan_id = support::seed_player(&db.conn, "CoolBuilder42", &Game::Minecraft).await;
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+
+    let body = minecraft_position_body("CoolBuilder42", Some("java-uuid-1"), None);
+    let resp = client
+        .post("/api/position")
+        .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(
+        players.len(),
+        2,
+        "orphan + XBL records, no third created; found: {:?}",
+        players.iter().map(|p| (&p.id, &p.gamertag)).collect::<Vec<_>>()
+    );
+    let ids: std::collections::HashSet<i32> = players.iter().map(|p| p.id).collect();
+    assert!(ids.contains(&orphan_id), "orphan record should still exist");
+    assert!(ids.contains(&xbl_id), "XBL record should still exist");
+}
+
+#[tokio::test]
+async fn migrations_apply_against_in_memory_db() {
+    let db = support::fresh_in_memory_db().await;
+    let pong = sea_orm::ConnectionTrait::execute_unprepared(db.as_ref(), "SELECT 1").await;
+    assert!(pong.is_ok());
+}
+
+#[tokio::test]
+async fn fake_authenticator_returns_canned_result() {
+    use common::auth::{AuthResult, MinecraftAuthenticator};
+    let fake = support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("Tag".into(), "pic".into())
+            .with_java_profile(Some("Java".into()), Some("uuid-1".into()))
+    ));
+    let r = fake.authenticate("code".into(), "http://x/cb".parse().unwrap()).await.unwrap();
+    assert_eq!(r.gamertag, "Tag");
+    assert_eq!(r.minecraft_username.as_deref(), Some("Java"));
+    assert_eq!(r.minecraft_uuid.as_deref(), Some("uuid-1"));
+}
+
+#[tokio::test]
+async fn test_client_builds_and_responds() {
+    use common::auth::AuthResult;
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("uuid-1".into()))
+    )));
+    let client = support::build_test_client(db, fake).await;
+
+    let body = serde_json::json!({
+        "code": "auth-code",
+        "redirect_uri": "http://app/cb"
+    });
+    let response = client.post("/api/auth/minecraft").json(&body).dispatch().await;
+    let _ = response.status();
+}
+
+#[tokio::test]
+async fn b1_xbl_first_creates_both_aliases() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::{player, player_identity};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("java-uuid-1".into()))
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok, "login should succeed");
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref()).await.unwrap();
+    assert_eq!(players.len(), 1);
+    assert_eq!(players[0].gamertag.as_deref(), Some("AwesomeXboxer123"));
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(players[0].id))
+        .all(db.as_ref()).await.unwrap();
+    let kinds: std::collections::HashSet<_> = aliases.iter()
+        .map(|a| (a.alias.clone(), a.alias_type.clone())).collect();
+    assert!(
+        kinds.contains(&("CoolBuilder42".to_string(), "minecraft_services".to_string())),
+        "expected minecraft_services alias for CoolBuilder42"
+    );
+    assert!(
+        kinds.contains(&("java-uuid-1".to_string(), "platform_uuid".to_string())),
+        "expected platform_uuid alias for java-uuid-1"
+    );
+}
+
+#[tokio::test]
+async fn b2_same_gamertag_and_java_name_skips_name_alias() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::player_identity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    support::seed_player(&db.conn, "Same", &Game::Minecraft).await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("Same".into(), "pic".into())
+            .with_java_profile(Some("Same".into()), Some("uuid-x".into()))
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref()).await.unwrap();
+
+    let types: std::collections::HashSet<_> = aliases.iter().map(|a| a.alias_type.clone()).collect();
+    assert!(types.contains("platform_uuid"), "platform_uuid should be present");
+    assert!(!types.contains("minecraft_services"), "minecraft_services should be SKIPPED when java==gamertag");
+}
+
+#[tokio::test]
+async fn b3_bedrock_only_account_writes_no_aliases() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::{player, player_identity};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    support::seed_player(&db.conn, "BedrockGuy", &Game::Minecraft).await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("BedrockGuy".into(), "pic".into())
+            .with_java_profile(None, None)
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref()).await.unwrap();
+    assert_eq!(players.len(), 1);
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref()).await.unwrap();
+    assert_eq!(aliases.len(), 0);
+}
+
+#[tokio::test]
+async fn b4_java_first_then_xbl_login_creates_fresh_xbl_record_and_repoints_aliases() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::{player, player_identity};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+
+    let java_id = support::seed_player(&db.conn, "CoolBuilder42", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, java_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("java-uuid-1".into()))
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref()).await.unwrap();
+    let xbl_record = players.iter()
+        .find(|p| p.gamertag.as_deref() == Some("AwesomeXboxer123"))
+        .expect("new XBL record must exist");
+    assert!(players.iter().any(|p| p.id == java_id),
+        "orphan Java-first record should remain");
+
+    let uuid_alias: player_identity::Model = player_identity::Entity::find()
+        .filter(player_identity::Column::Alias.eq("java-uuid-1"))
+        .filter(player_identity::Column::AliasType.eq("platform_uuid"))
+        .one(db.as_ref()).await.unwrap()
+        .expect("uuid alias");
+    assert_eq!(uuid_alias.player_id, xbl_record.id,
+        "UUID alias must re-point to the new XBL record");
+
+    let name_alias: player_identity::Model = player_identity::Entity::find()
+        .filter(player_identity::Column::Alias.eq("CoolBuilder42"))
+        .filter(player_identity::Column::AliasType.eq("minecraft_services"))
+        .one(db.as_ref()).await.unwrap()
+        .expect("name alias");
+    assert_eq!(name_alias.player_id, xbl_record.id,
+        "Java name alias must point to the new XBL record");
+}
+
+#[tokio::test]
+async fn b5_operator_whitelist_race_repoints_aliases_to_xbl() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::player_identity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    let java_id = support::seed_player(&db.conn, "CoolBuilder42", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, java_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("java-uuid-1".into()))
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let uuid_alias: player_identity::Model = player_identity::Entity::find()
+        .filter(player_identity::Column::Alias.eq("java-uuid-1"))
+        .filter(player_identity::Column::AliasType.eq("platform_uuid"))
+        .one(db.as_ref()).await.unwrap()
+        .expect("uuid alias");
+    assert_eq!(uuid_alias.player_id, xbl_id,
+        "alias should re-point to operator-whitelisted XBL record");
+}
+
+#[tokio::test]
+async fn b6_idempotent_relogin_does_not_duplicate_aliases() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::player_identity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "java-uuid-1", "platform_uuid", &Game::Minecraft).await;
+    support::seed_alias(&db.conn, xbl_id, "CoolBuilder42", "minecraft_services", &Game::Minecraft).await;
+
+    let make_fake = || std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("java-uuid-1".into()))
+    )));
+
+    {
+        let client = support::build_test_client(db.clone(), make_fake()).await;
+        client.post("/api/auth/minecraft")
+            .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+            .dispatch().await;
+    }
+    {
+        let client = support::build_test_client(db.clone(), make_fake()).await;
+        client.post("/api/auth/minecraft")
+            .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+            .dispatch().await;
+    }
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(xbl_id))
+        .all(db.as_ref()).await.unwrap();
+    assert_eq!(aliases.len(), 2, "no duplicate aliases after relogin");
+}
+
+#[tokio::test]
+async fn b7_alias_creation_failure_is_non_fatal() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use sea_orm::ConnectionTrait;
+
+    let db = support::fresh_in_memory_db().await;
+    let _xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+
+    db.as_ref().execute_unprepared("DROP TABLE player_identity").await.unwrap();
+
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), Some("uuid".into()))
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok,
+        "login still succeeds even if alias creation errors");
+}
+
+#[tokio::test]
+async fn r1_full_round_trip_java_first_then_xbl_then_position() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::player;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+
+    // Step 1: Java player joins via Fabric mod — auto-register creates the Java-first record.
+    {
+        let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+            common::auth::AuthError::AuthenticationFailed("unused".into()),
+        )));
+        let client = support::build_test_client(db.clone(), fake).await;
+        let body = minecraft_position_body("CoolBuilder42", Some("java-uuid-1"), None);
+        let resp = client
+            .post("/api/position")
+            .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+            .json(&body)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), rocket::http::Status::Ok);
+    }
+
+    // Verify Java-first state.
+    {
+        let players: Vec<player::Model> = player::Entity::find()
+            .filter(player::Column::Game.eq(Game::Minecraft))
+            .all(db.as_ref())
+            .await
+            .unwrap();
+        assert_eq!(players.len(), 1);
+        assert_eq!(players[0].gamertag.as_deref(), Some("CoolBuilder42"));
+    }
+
+    // Step 2: XBL login arrives — Phase B re-mapping creates new XBL record.
+    {
+        let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+            AuthResult::new("AwesomeXboxer123".into(), "pic".into())
+                .with_java_profile(Some("CoolBuilder42".into()), Some("java-uuid-1".into())),
+        )));
+        let client = support::build_test_client(db.clone(), fake).await;
+        let resp = client
+            .post("/api/auth/minecraft")
+            .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), rocket::http::Status::Ok);
+    }
+
+    // Verify two records (Java-first orphan + new XBL).
+    {
+        let players: Vec<player::Model> = player::Entity::find()
+            .filter(player::Column::Game.eq(Game::Minecraft))
+            .all(db.as_ref())
+            .await
+            .unwrap();
+        assert_eq!(players.len(), 2);
+        assert!(players.iter().any(|p| p.gamertag.as_deref() == Some("CoolBuilder42")));
+        assert!(players.iter().any(|p| p.gamertag.as_deref() == Some("AwesomeXboxer123")));
+    }
+
+    // Step 3: Java player sends another position — UUID pre-resolution remaps to the XBL record.
+    {
+        let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Err(
+            common::auth::AuthError::AuthenticationFailed("unused".into()),
+        )));
+        let client = support::build_test_client(db.clone(), fake).await;
+        let body = minecraft_position_body("CoolBuilder42", Some("java-uuid-1"), None);
+        let resp = client
+            .post("/api/position")
+            .header(rocket::http::Header::new("X-MC-Access-Token", "test-bypass-token"))
+            .json(&body)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), rocket::http::Status::Ok);
+    }
+
+    // Final: still exactly two player records (no third created via duplicate auto-register).
+    let players: Vec<player::Model> = player::Entity::find()
+        .filter(player::Column::Game.eq(Game::Minecraft))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(
+        players.len(),
+        2,
+        "no third record should be created — UUID pre-resolution shadows the orphan"
+    );
+}
+
+// link_java_identity requires mTLS (Certificate<'_> guard) which is not available
+// in the test Rocket instance. The route itself has been refactored to use the
+// MinecraftAuthenticator trait (Option A), but the mTLS guard prevents exercising
+// it via the HTTP client in tests without a full TLS stack.
+#[ignore]
+#[tokio::test]
+async fn link_java_endpoint_creates_minecraft_services_alias() {
+    use common::auth::AuthResult;
+    use common::Game;
+    use entity::player_identity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let db = support::fresh_in_memory_db().await;
+    let xbl_id = support::seed_player(&db.conn, "AwesomeXboxer123", &Game::Minecraft).await;
+
+    // authenticate_for_java_profile extracts minecraft_username from the canned AuthResult.
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("ignored-gamertag".into(), "ignored-pic".into())
+            .with_java_profile(Some("CoolBuilder42".into()), None),
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let body = serde_json::json!({
+        "code": "auth-code",
+        "redirect_uri": "http://app/cb",
+        "client_id": "test-client-id",
+        "gamertag": "AwesomeXboxer123"
+    });
+    let resp = client
+        .post("/api/auth/link-java")
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), rocket::http::Status::Ok);
+
+    let aliases: Vec<player_identity::Model> = player_identity::Entity::find()
+        .filter(player_identity::Column::PlayerId.eq(xbl_id))
+        .filter(player_identity::Column::AliasType.eq("minecraft_services"))
+        .all(db.as_ref())
+        .await
+        .unwrap();
+    assert!(
+        aliases.iter().any(|a| a.alias == "CoolBuilder42"),
+        "/auth/link-java should create a minecraft_services alias for the Java username"
+    );
+}
+
+#[tokio::test]
+async fn b0_unknown_player_without_java_alias_is_rejected() {
+    use common::auth::AuthResult;
+    use sea_orm::EntityTrait;
+
+    let db = support::fresh_in_memory_db().await;
+    let fake = std::sync::Arc::new(support::FakeMinecraftAuthenticator::new(Ok(
+        AuthResult::new("UnknownPlayer".into(), "pic".into())
+            .with_java_profile(None, None)
+    )));
+    let client = support::build_test_client(db.clone(), fake).await;
+
+    let resp = client.post("/api/auth/minecraft")
+        .json(&serde_json::json!({ "code": "c", "redirect_uri": "http://app/cb" }))
+        .dispatch().await;
+    assert_eq!(resp.status(), rocket::http::Status::Forbidden,
+        "non-whitelisted player without Java UUID match must be rejected");
+
+    let players: Vec<entity::player::Model> = entity::player::Entity::find()
+        .all(db.as_ref()).await.unwrap();
+    assert_eq!(players.len(), 0, "no player should be created");
+}

--- a/server/server/tests/support/mod.rs
+++ b/server/server/tests/support/mod.rs
@@ -1,0 +1,148 @@
+//! Shared test fixtures for cross-cutting integration tests.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use async_trait::async_trait;
+use common::auth::{AuthError, AuthResult, MinecraftAuthenticator};
+use migration::{Migrator, MigratorTrait};
+use parking_lot::Mutex;
+use reqwest::Url;
+use sea_orm::{Database, DatabaseConnection};
+
+static DB_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// A shared in-memory SQLite database for integration tests.
+///
+/// Both the Rocket AppDb pool and the PlayerIdentityService connect to the same
+/// named SQLite shared-cache URL so writes from either path are visible to the
+/// other and to test-side queries on `conn`.
+#[derive(Clone)]
+pub struct TestDb {
+    pub conn: Arc<DatabaseConnection>,
+    pub url: String,
+}
+
+impl AsRef<DatabaseConnection> for TestDb {
+    fn as_ref(&self) -> &DatabaseConnection {
+        self.conn.as_ref()
+    }
+}
+
+pub async fn fresh_in_memory_db() -> TestDb {
+    let id = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let url = format!("sqlite:file:bvc_test_{}?mode=memory&cache=shared", id);
+
+    let conn = Database::connect(url.as_str())
+        .await
+        .expect("connect to named sqlite memory");
+    Migrator::up(&conn, None)
+        .await
+        .expect("run migrations against in-memory sqlite");
+
+    TestDb {
+        conn: Arc::new(conn),
+        url,
+    }
+}
+
+pub struct FakeMinecraftAuthenticator {
+    canned: Mutex<Option<Result<AuthResult, AuthError>>>,
+}
+
+impl FakeMinecraftAuthenticator {
+    pub fn new(result: Result<AuthResult, AuthError>) -> Self {
+        Self { canned: Mutex::new(Some(result)) }
+    }
+}
+
+#[async_trait]
+impl MinecraftAuthenticator for FakeMinecraftAuthenticator {
+    async fn authenticate(
+        &self,
+        _code: String,
+        _redirect_uri: Url,
+    ) -> Result<AuthResult, AuthError> {
+        self.canned
+            .lock()
+            .take()
+            .expect("FakeMinecraftAuthenticator: authenticate called more than once or unset")
+    }
+
+    async fn authenticate_for_java_profile(
+        &self,
+        _code: String,
+        _redirect_uri: Url,
+    ) -> Result<String, AuthError> {
+        let result = self
+            .canned
+            .lock()
+            .take()
+            .expect("FakeMinecraftAuthenticator: authenticate_for_java_profile called more than once or unset");
+        result.and_then(|auth| {
+            auth.minecraft_username.ok_or(AuthError::AuthenticationFailed(
+                "no java username in canned AuthResult".into(),
+            ))
+        })
+    }
+}
+
+pub async fn seed_player(
+    conn: &Arc<DatabaseConnection>,
+    gamertag: &str,
+    game: &common::Game,
+) -> i32 {
+    use sea_orm::{ActiveModelTrait, ActiveValue};
+    let m = entity::player::ActiveModel {
+        gamertag: ActiveValue::Set(Some(gamertag.into())),
+        gamerpic: ActiveValue::Set(None),
+        certificate: ActiveValue::Set(String::new()),
+        certificate_key: ActiveValue::Set(String::new()),
+        banished: ActiveValue::Set(false),
+        keypair: ActiveValue::Set(vec![0u8; 64]),
+        signature: ActiveValue::Set(vec![0u8; 96]),
+        created_at: ActiveValue::Set(0),
+        updated_at: ActiveValue::Set(0),
+        game: ActiveValue::Set(game.clone()),
+        ..Default::default()
+    };
+    let inserted = m.insert(conn.as_ref()).await.expect("seed player insert");
+    inserted.id
+}
+
+pub async fn seed_alias(
+    conn: &Arc<DatabaseConnection>,
+    player_id: i32,
+    alias: &str,
+    alias_type: &str,
+    game: &common::Game,
+) {
+    use sea_orm::{ActiveModelTrait, ActiveValue};
+    let m = entity::player_identity::ActiveModel {
+        player_id: ActiveValue::Set(player_id),
+        alias: ActiveValue::Set(alias.into()),
+        alias_type: ActiveValue::Set(alias_type.into()),
+        game: ActiveValue::Set(game.clone()),
+        created_at: ActiveValue::Set(0),
+        updated_at: ActiveValue::Set(0),
+        ..Default::default()
+    };
+    m.insert(conn.as_ref()).await.expect("seed alias insert");
+}
+
+pub async fn build_test_client(
+    db: TestDb,
+    authenticator: Arc<dyn MinecraftAuthenticator>,
+) -> rocket::local::asynchronous::Client {
+    let rocket = bvc_server_lib::build_test_rocket(
+        authenticator,
+        db.url.clone(),
+    )
+    .await;
+
+    rocket::local::asynchronous::Client::tracked(rocket)
+        .await
+        .expect("test rocket client")
+}


### PR DESCRIPTION
## Description
Resolves the case where a player's Mojang username differs from their Xbox Live gamertag, causing BVC to treat them as two separate players (one per identity surface) and breaking voice routing between their desktop client and their Java Minecraft session.

#### Position Ingest
- Java-first auto-register: when the Fabric/Paper mod sends a position for an unknown player, BVC creates the record AND writes a self-pointing (java_uuid → player_id) alias.
- UUID pre-resolution: position handler resolves by platform_uuid alias before name, shadowing orphan records and surviving Mojang username renames.
- Username drift refresh: stale minecraft_services alias is updated to the current Java name when UUID matches.
- Floodgate path preserved: existing alternative_identity handling for Bedrock-via-Geyser players is untouched.

#### Login-time merge
> This is currently pending approval from Mojang for `a17f9693-f01f-4d1d-ad12-1f179478375d` to get access to Java Services. If Mojang rejects this request, we'll need to abandon this branch in favor of a second OAuth2 leg, or something else.

4/26: Request submitted
5/3: Still pending a response from Mojang. No response thus far

----

- XBL-first fresh login on a whitelisted gamertag writes both minecraft_services and platform_uuid aliases.
- Same gamertag/Java-username combo skips the redundant name alias.
- Bedrock-only accounts (no Java license) are non-fatal: 404 logged at info, login still succeeds.
- Java-first → XBL-second (the primary case): XBL login of a player whose Java identity is already auto-registered creates a fresh XBL-keyed record and re-points the existing UUID alias from the Java-first orphan to the new XBL record.
- Operator-whitelist race: pre-existing XBL record + concurrent Java-first record reconciles to the XBL record.
- Idempotent re-login: no duplicate aliases.
- Alias-creation failures are non-fatal; the route still returns 200.

#### Whitelist invariant preserved
- unknown players (no XBL record AND no Java UUID alias) get 403, unchanged.
- /auth/link-java regression test is #[ignore]-d due to the route's mTLS Certificate<'_> guard requiring a non-trivial test harness; production refactor is correct.
- Phase B's MS Services calls return 403 in production until Mojang approves the app registration. Code is non-fatal until then; Phase A delivers the working subset.

Test coverage
- New .github/workflows/test-server.yml runs the suite on every PR touching server/** or common/**, wired into build-all.yml.


## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).