### PR TITLE
fix: #169 ca-resigning

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "read-process-memory",
  "redcon",
  "reqwest 0.12.28",
+ "ring",
  "ringbuf",
  "rocket",
  "rocket_cors",
@@ -695,6 +696,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -705,6 +707,7 @@ dependencies = [
  "uuid",
  "windows 0.62.2",
  "windows-targets 0.53.5",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]

--- a/server/server/Cargo.toml
+++ b/server/server/Cargo.toml
@@ -97,6 +97,9 @@ ringbuf = { version = "0.4" }
 hound = "^3.5"
 read-process-memory = "0.1.6"
 proc_mem = "0.1.6"
+tempfile = "3"
+ring = "0.17"
+x509-parser = "0.16"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 libsqlite3-sys = { version = "^0.30", features = ["bundled"] }

--- a/server/server/src/config/app/server/mod.rs
+++ b/server/server/src/config/app/server/mod.rs
@@ -15,11 +15,11 @@ fn default_listen() -> String {
 }
 
 fn default_http_port() -> u32 {
-    8444
+    443
 }
 
 fn default_quic_port() -> u32 {
-    8443
+    443
 }
 
 fn default_assets_path() -> String {

--- a/server/server/src/runtime/ca_cert.rs
+++ b/server/server/src/runtime/ca_cert.rs
@@ -1,0 +1,678 @@
+//! CA certificate management for the QUIC server.
+//!
+//! The CA cert serves two roles:
+//! 1. The QUIC server's TLS leaf cert, presented during the handshake.
+//! 2. The trust root that issues player mTLS client certs.
+//!
+//! The keypair (`ca.key`) is generated once on first start and never replaced.
+//! The cert (`ca.crt`) is re-signed with the same keypair whenever the configured
+//! SAN set drifts from what is embedded in the cert. This preserves the chain of
+//! trust for every player cert ever issued, and keeps the Subject DN + SPKI of
+//! the trust anchor stable for clients that have pinned the root cert.
+
+use anyhow::{anyhow, Context, Result};
+use rcgen::{
+    CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    KeyUsagePurpose, SanType,
+};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use time::{Duration, OffsetDateTime};
+use tracing::info;
+
+const CA_SUBJECT_CN: &str = "Bedrock Voice Chat";
+
+/// Manages generation and persistence of the CA certificate and keypair.
+pub struct CaCertManager {
+    certs_path: String,
+}
+
+impl CaCertManager {
+    pub fn new(certs_path: &str) -> Self {
+        Self {
+            certs_path: certs_path.to_string(),
+        }
+    }
+
+    /// Ensure `ca.crt` and `ca.key` exist at the configured path and that the
+    /// cert's SANs match `san_strings`. Returns `(cert_pem, key_pem)` on success.
+    ///
+    /// Behavior:
+    /// - If `ca.key` is missing, a fresh keypair is generated and persisted.
+    /// - If `ca.key` exists, it is reused and never rewritten.
+    /// - If `ca.crt` is missing or its SAN set differs from `san_strings`, the cert
+    ///   is re-signed with the (existing or freshly generated) keypair and written
+    ///   atomically.
+    pub fn ensure(&self, san_strings: &[String]) -> Result<(String, String)> {
+        let dir = Path::new(&self.certs_path);
+        if !dir.exists() {
+            fs::create_dir_all(dir)
+                .with_context(|| format!("creating certs dir {}", dir.display()))?;
+        }
+        let cert_path = dir.join("ca.crt");
+        let key_path = dir.join("ca.key");
+
+        let (keypair, key_pem) = Self::load_or_create_keypair(&key_path)?;
+        let desired = Self::build_desired_san_keys(san_strings)?;
+
+        if cert_path.exists() {
+            let existing_pem = fs::read_to_string(&cert_path)
+                .with_context(|| format!("reading ca.crt at {}", cert_path.display()))?;
+            let existing = Self::parse_existing_san_keys(&existing_pem)?;
+            if existing == desired {
+                return Ok((existing_pem, key_pem));
+            }
+            info!(
+                "ca.crt SAN set drifted from config (was: {:?}, now: {:?}); re-signing with existing keypair",
+                Self::sorted(&existing),
+                Self::sorted(&desired),
+            );
+        }
+
+        let new_cert_pem = Self::sign_ca_cert(&keypair, san_strings)?;
+        Self::write_atomically(&cert_path, &new_cert_pem)?;
+        Ok((new_cert_pem, key_pem))
+    }
+
+    /// Canonical, comparable string form of a SAN entry. DNS names are lowercased
+    /// (DNS names are case-insensitive per RFC 5280 §4.2.1.6); IP addresses use
+    /// their `std::net::IpAddr` Display form, which is canonical for both v4 and v6.
+    fn san_key(san: &SanType) -> String {
+        match san {
+            SanType::DnsName(name) => format!("DNS:{}", name.as_ref().to_ascii_lowercase()),
+            SanType::IpAddress(ip) => format!("IP:{}", ip),
+            SanType::Rfc822Name(name) => format!("EMAIL:{}", name.as_ref().to_ascii_lowercase()),
+            SanType::URI(uri) => format!("URI:{}", uri.as_ref()),
+            other => format!("OTHER:{:?}", other),
+        }
+    }
+
+    /// Build the desired SAN key set from raw config strings. Routes through
+    /// `rcgen::CertificateParams::new` so DNS-vs-IP detection follows rcgen's own
+    /// rules, which is the same rule used when generating the cert.
+    fn build_desired_san_keys(strings: &[String]) -> Result<HashSet<String>> {
+        let params = CertificateParams::new(strings.to_vec())
+            .map_err(|e| anyhow!("invalid SAN entry in config: {e}"))?;
+        Ok(params.subject_alt_names.iter().map(Self::san_key).collect())
+    }
+
+    /// Read the SAN set out of an existing CA cert PEM. Uses `rcgen`'s built-in
+    /// x509 parser (the `x509-parser` feature is enabled in Cargo.toml).
+    fn parse_existing_san_keys(pem: &str) -> Result<HashSet<String>> {
+        let params = CertificateParams::from_ca_cert_pem(pem)
+            .map_err(|e| anyhow!("failed to parse existing ca.crt: {e}"))?;
+        Ok(params.subject_alt_names.iter().map(Self::san_key).collect())
+    }
+
+    /// Load `ca.key` from disk if it exists, otherwise generate a new keypair and
+    /// write it. Returns the keypair and the PEM we have on disk for it.
+    ///
+    /// This is the trust-anchor invariant: the keypair is generated **exactly once**
+    /// per `certs_path` for the lifetime of the deployment. Replacing it would
+    /// invalidate every leaf cert ever signed by it.
+    fn load_or_create_keypair(key_path: &Path) -> Result<(KeyPair, String)> {
+        if key_path.exists() {
+            let pem = fs::read_to_string(key_path)
+                .with_context(|| format!("reading ca.key at {}", key_path.display()))?;
+            let kp = KeyPair::from_pem(&pem)
+                .map_err(|e| anyhow!("parsing ca.key at {}: {e}", key_path.display()))?;
+            Ok((kp, pem))
+        } else {
+            let kp = KeyPair::generate()
+                .map_err(|e| anyhow!("generating ca.key: {e}"))?;
+            let pem = kp.serialize_pem();
+            fs::write(key_path, &pem)
+                .with_context(|| format!("writing ca.key at {}", key_path.display()))?;
+            Ok((kp, pem))
+        }
+    }
+
+    /// Self-sign a CA cert with `keypair`, embedding `san_strings` and the fixed
+    /// Subject DN, IsCa, key usage, and extended key usage that this server has
+    /// always used. Validity starts 3 days in the past (matches prior behavior to
+    /// tolerate clock skew on first connect) and runs for 90 days; a periodic
+    /// re-sign on operator restart keeps the cert fresh without changing the trust
+    /// anchor identity.
+    fn sign_ca_cert(keypair: &KeyPair, san_strings: &[String]) -> Result<String> {
+        let mut params = CertificateParams::new(san_strings.to_vec())
+            .map_err(|e| anyhow!("invalid SAN entry: {e}"))?;
+        let mut dn = DistinguishedName::new();
+        dn.push(rcgen::DnType::CommonName, CA_SUBJECT_CN);
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::NoCa;
+        params.use_authority_key_identifier_extension = true;
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        params.extended_key_usages = vec![
+            ExtendedKeyUsagePurpose::ClientAuth,
+            ExtendedKeyUsagePurpose::ServerAuth,
+        ];
+        params.not_before = OffsetDateTime::now_utc()
+            .checked_sub(Duration::days(3))
+            .ok_or_else(|| anyhow!("not_before underflow"))?;
+        params.not_after = OffsetDateTime::now_utc()
+            .checked_add(Duration::days(90))
+            .ok_or_else(|| anyhow!("not_after overflow"))?;
+        let cert = params
+            .self_signed(keypair)
+            .map_err(|e| anyhow!("self-signing ca.crt: {e}"))?;
+        Ok(cert.pem())
+    }
+
+    /// Write `content` to `path` atomically: write to `<path>.tmp`, then rename.
+    /// Prevents leaving a half-written `ca.crt` if the process is killed mid-write.
+    fn write_atomically(path: &Path, content: &str) -> Result<()> {
+        let tmp: PathBuf = {
+            let mut p = path.as_os_str().to_owned();
+            p.push(".tmp");
+            PathBuf::from(p)
+        };
+        fs::write(&tmp, content)
+            .with_context(|| format!("writing tmp file {}", tmp.display()))?;
+        fs::rename(&tmp, path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    fn sorted(set: &HashSet<String>) -> Vec<String> {
+        let mut v: Vec<_> = set.iter().cloned().collect();
+        v.sort();
+        v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs as stdfs;
+    use tempfile::TempDir;
+
+    fn s(v: &str) -> String { v.to_string() }
+
+    #[test]
+    fn san_key_normalizes_dns() {
+        let san = SanType::DnsName("Example.com".to_string().try_into().unwrap());
+        assert_eq!(CaCertManager::san_key(&san), "DNS:example.com");
+    }
+
+    #[test]
+    fn san_key_normalizes_ipv4() {
+        let san = SanType::IpAddress(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)));
+        assert_eq!(CaCertManager::san_key(&san), "IP:127.0.0.1");
+    }
+
+    #[test]
+    fn san_key_normalizes_ipv6() {
+        let san = SanType::IpAddress(std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST));
+        assert_eq!(CaCertManager::san_key(&san), "IP:::1");
+    }
+
+    #[test]
+    fn build_desired_san_keys_mixes_dns_and_ip() {
+        let got = CaCertManager::build_desired_san_keys(&[s("localhost"), s("127.0.0.1"), s("::1")]).unwrap();
+        let want: HashSet<String> = ["DNS:localhost", "IP:127.0.0.1", "IP:::1"]
+            .iter().map(|s| s.to_string()).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn build_desired_san_keys_dedupes_and_is_order_independent() {
+        let a = CaCertManager::build_desired_san_keys(&[s("a.example"), s("b.example"), s("a.example")]).unwrap();
+        let b = CaCertManager::build_desired_san_keys(&[s("b.example"), s("a.example")]).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 2);
+    }
+
+    #[test]
+    fn build_desired_san_keys_lowercases_dns() {
+        let got = CaCertManager::build_desired_san_keys(&[s("Mixed.Case.EXAMPLE")]).unwrap();
+        assert!(got.contains("DNS:mixed.case.example"));
+    }
+
+    fn build_test_cert_pem(san_strings: &[String]) -> String {
+        let params = CertificateParams::new(san_strings.to_vec()).unwrap();
+        let kp = KeyPair::generate().unwrap();
+        params.self_signed(&kp).unwrap().pem()
+    }
+
+    #[test]
+    fn parse_existing_san_keys_reads_dns_and_ip() {
+        let pem = build_test_cert_pem(&[s("foo.example"), s("10.0.0.1"), s("::1")]);
+        let got = CaCertManager::parse_existing_san_keys(&pem).unwrap();
+        let want: HashSet<String> = ["DNS:foo.example", "IP:10.0.0.1", "IP:::1"]
+            .iter().map(|s| s.to_string()).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn parse_existing_san_keys_returns_empty_when_no_san_extension() {
+        let mut params = CertificateParams::default();
+        params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, "no-san-here");
+            dn
+        };
+        let kp = KeyPair::generate().unwrap();
+        let pem = params.self_signed(&kp).unwrap().pem();
+        let got = CaCertManager::parse_existing_san_keys(&pem).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn parse_existing_san_keys_errors_on_garbage() {
+        let err = CaCertManager::parse_existing_san_keys("not a pem").unwrap_err();
+        assert!(format!("{err}").contains("parse"));
+    }
+
+    #[test]
+    fn load_or_create_keypair_creates_when_absent() {
+        let dir = TempDir::new().unwrap();
+        let key_path = dir.path().join("ca.key");
+        let (kp, pem) = CaCertManager::load_or_create_keypair(&key_path).unwrap();
+        assert!(key_path.exists());
+        assert_eq!(stdfs::read_to_string(&key_path).unwrap(), pem);
+        let kp_pem = kp.serialize_pem();
+        assert_eq!(kp_pem, pem);
+    }
+
+    #[test]
+    fn load_or_create_keypair_reuses_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let key_path = dir.path().join("ca.key");
+        let (_kp1, pem1) = CaCertManager::load_or_create_keypair(&key_path).unwrap();
+        let mtime1 = stdfs::metadata(&key_path).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let (_kp2, pem2) = CaCertManager::load_or_create_keypair(&key_path).unwrap();
+        let mtime2 = stdfs::metadata(&key_path).unwrap().modified().unwrap();
+        assert_eq!(pem1, pem2, "key PEM must not change on reload");
+        assert_eq!(mtime1, mtime2, "ca.key file must not be rewritten on reload");
+    }
+
+    #[test]
+    fn load_or_create_keypair_errors_when_dir_missing() {
+        let bogus = std::path::PathBuf::from("/nonexistent/definitely/missing/ca.key");
+        let err = CaCertManager::load_or_create_keypair(&bogus).unwrap_err();
+        let s = format!("{err}");
+        assert!(s.to_lowercase().contains("ca.key") || s.to_lowercase().contains("no such"));
+    }
+
+    #[test]
+    fn sign_ca_cert_embeds_configured_sans() {
+        let kp = KeyPair::generate().unwrap();
+        let pem = CaCertManager::sign_ca_cert(&kp, &[s("a.example"), s("10.0.0.1")]).unwrap();
+        let sans = CaCertManager::parse_existing_san_keys(&pem).unwrap();
+        assert!(sans.contains("DNS:a.example"));
+        assert!(sans.contains("IP:10.0.0.1"));
+        assert_eq!(sans.len(), 2);
+    }
+
+    #[test]
+    fn sign_ca_cert_uses_fixed_subject_cn() {
+        let kp = KeyPair::generate().unwrap();
+        let pem = CaCertManager::sign_ca_cert(&kp, &[s("localhost")]).unwrap();
+        let parsed = CertificateParams::from_ca_cert_pem(&pem).unwrap();
+        let (_, cn_value) = parsed.distinguished_name
+            .iter()
+            .find(|(ty, _)| **ty == rcgen::DnType::CommonName)
+            .expect("CN must be set");
+        match cn_value {
+            rcgen::DnValue::Utf8String(v) => assert_eq!(v, CA_SUBJECT_CN),
+            rcgen::DnValue::PrintableString(v) => assert_eq!(v.as_str(), CA_SUBJECT_CN),
+            other => panic!("unexpected CN value type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sign_ca_cert_includes_eku_client_and_server_auth() {
+        let kp = KeyPair::generate().unwrap();
+        let pem = CaCertManager::sign_ca_cert(&kp, &[s("localhost")]).unwrap();
+        let parsed = CertificateParams::from_ca_cert_pem(&pem).unwrap();
+        assert!(parsed.extended_key_usages.contains(&ExtendedKeyUsagePurpose::ClientAuth));
+        assert!(parsed.extended_key_usages.contains(&ExtendedKeyUsagePurpose::ServerAuth));
+    }
+
+    #[test]
+    fn sign_ca_cert_includes_keycertsign_key_usage() {
+        let kp = KeyPair::generate().unwrap();
+        let pem = CaCertManager::sign_ca_cert(&kp, &[s("localhost")]).unwrap();
+        let parsed = CertificateParams::from_ca_cert_pem(&pem).unwrap();
+        assert!(parsed.key_usages.contains(&KeyUsagePurpose::KeyCertSign));
+    }
+
+    #[test]
+    fn sign_ca_cert_with_same_keypair_produces_byte_identical_spki() {
+        use x509_parser::prelude::*;
+
+        let kp = KeyPair::generate().unwrap();
+        let pem_a = CaCertManager::sign_ca_cert(&kp, &[s("a.example")]).unwrap();
+        let pem_b = CaCertManager::sign_ca_cert(&kp, &[s("b.example"), s("c.example")]).unwrap();
+
+        let spki_of = |pem: &str| -> Vec<u8> {
+            let (_, p) = x509_parser::pem::parse_x509_pem(pem.as_bytes()).unwrap();
+            let (_, cert) = X509Certificate::from_der(&p.contents).unwrap();
+            cert.tbs_certificate.subject_pki.raw.to_vec()
+        };
+        assert_eq!(spki_of(&pem_a), spki_of(&pem_b));
+    }
+
+    #[test]
+    fn write_atomically_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("ca.crt");
+        CaCertManager::write_atomically(&target, "hello").unwrap();
+        assert_eq!(stdfs::read_to_string(&target).unwrap(), "hello");
+        let leftover: Vec<_> = stdfs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(leftover.is_empty(), "no .tmp files should remain");
+    }
+
+    #[test]
+    fn write_atomically_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("ca.crt");
+        stdfs::write(&target, "old").unwrap();
+        CaCertManager::write_atomically(&target, "new").unwrap();
+        assert_eq!(stdfs::read_to_string(&target).unwrap(), "new");
+    }
+
+    fn read_pems(certs_path: &Path) -> (String, String) {
+        let cert = stdfs::read_to_string(certs_path.join("ca.crt")).unwrap();
+        let key = stdfs::read_to_string(certs_path.join("ca.key")).unwrap();
+        (cert, key)
+    }
+
+    #[test]
+    fn ensure_first_run_generates_both_files() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        let (cert_pem, key_pem) = mgr.ensure(&[s("localhost"), s("127.0.0.1")]).unwrap();
+        assert!(dir.path().join("ca.crt").exists());
+        assert!(dir.path().join("ca.key").exists());
+        let (disk_cert, disk_key) = read_pems(dir.path());
+        assert_eq!(cert_pem, disk_cert);
+        assert_eq!(key_pem, disk_key);
+        let sans = CaCertManager::parse_existing_san_keys(&cert_pem).unwrap();
+        assert!(sans.contains("DNS:localhost"));
+        assert!(sans.contains("IP:127.0.0.1"));
+    }
+
+    #[test]
+    fn ensure_creates_certs_dir_if_missing() {
+        let outer = TempDir::new().unwrap();
+        let nested = outer.path().join("does/not/exist/yet");
+        let path = nested.to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        mgr.ensure(&[s("localhost")]).unwrap();
+        assert!(nested.join("ca.crt").exists());
+        assert!(nested.join("ca.key").exists());
+    }
+
+    #[test]
+    fn ensure_is_noop_when_sans_match() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let sans = vec![s("localhost"), s("127.0.0.1")];
+        let mgr = CaCertManager::new(path);
+        let (cert1, key1) = mgr.ensure(&sans).unwrap();
+        let cert_mtime_1 = stdfs::metadata(dir.path().join("ca.crt")).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let (cert2, key2) = mgr.ensure(&sans).unwrap();
+        let cert_mtime_2 = stdfs::metadata(dir.path().join("ca.crt")).unwrap().modified().unwrap();
+        assert_eq!(cert1, cert2, "cert PEM must be byte-equal across no-op runs");
+        assert_eq!(key1, key2, "key PEM must be byte-equal across no-op runs");
+        assert_eq!(cert_mtime_1, cert_mtime_2, "ca.crt must not be rewritten");
+    }
+
+    #[test]
+    fn ensure_is_order_and_dedup_insensitive() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+        let cert_mtime_1 = stdfs::metadata(dir.path().join("ca.crt")).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        mgr.ensure(&[s("b.example"), s("a.example"), s("a.example")]).unwrap();
+        let cert_mtime_2 = stdfs::metadata(dir.path().join("ca.crt")).unwrap().modified().unwrap();
+        assert_eq!(cert_mtime_1, cert_mtime_2, "ca.crt must not be rewritten on equivalent SAN set");
+    }
+
+    #[test]
+    fn ensure_rewrites_cert_when_sans_drift_but_keeps_key() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        let (cert1, key1) = mgr.ensure(&[s("a.example")]).unwrap();
+        let key_mtime_1 = stdfs::metadata(dir.path().join("ca.key")).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let (cert2, key2) = mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+        let key_mtime_2 = stdfs::metadata(dir.path().join("ca.key")).unwrap().modified().unwrap();
+
+        assert_ne!(cert1, cert2, "cert PEM must change when SANs drift");
+        assert_eq!(key1, key2, "key PEM must not change when SANs drift");
+        assert_eq!(key_mtime_1, key_mtime_2, "ca.key file must not be rewritten");
+
+        let sans2 = CaCertManager::parse_existing_san_keys(&cert2).unwrap();
+        assert!(sans2.contains("DNS:a.example"));
+        assert!(sans2.contains("DNS:b.example"));
+        assert_eq!(sans2.len(), 2);
+    }
+
+    #[test]
+    fn ensure_regenerates_cert_when_only_key_present() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let kp = KeyPair::generate().unwrap();
+        stdfs::write(dir.path().join("ca.key"), kp.serialize_pem()).unwrap();
+
+        let mgr = CaCertManager::new(path);
+        let (cert, key) = mgr.ensure(&[s("localhost")]).unwrap();
+        assert!(dir.path().join("ca.crt").exists());
+        assert_eq!(key, kp.serialize_pem());
+        let parsed = CertificateParams::from_ca_cert_pem(&cert).unwrap();
+        assert!(parsed.subject_alt_names.iter().any(|s| CaCertManager::san_key(s) == "DNS:localhost"));
+    }
+
+    #[test]
+    fn ensure_errors_on_corrupt_existing_cert() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let kp = KeyPair::generate().unwrap();
+        stdfs::write(dir.path().join("ca.key"), kp.serialize_pem()).unwrap();
+        stdfs::write(dir.path().join("ca.crt"), "not a real PEM").unwrap();
+        let mgr = CaCertManager::new(path);
+        let err = mgr.ensure(&[s("localhost")]).unwrap_err();
+        assert!(format!("{err}").contains("ca.crt"));
+    }
+
+    fn der_of(pem_str: &str) -> Vec<u8> {
+        let (_, p) = x509_parser::pem::parse_x509_pem(pem_str.as_bytes()).unwrap();
+        p.contents.to_vec()
+    }
+
+    #[test]
+    fn drift_resign_preserves_subject_dn_bytes() {
+        use x509_parser::prelude::*;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        let (cert_a, _) = mgr.ensure(&[s("a.example")]).unwrap();
+        let (cert_b, _) = mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+
+        let der_a = der_of(&cert_a);
+        let der_b = der_of(&cert_b);
+        let (_, ca) = X509Certificate::from_der(&der_a).unwrap();
+        let (_, cb) = X509Certificate::from_der(&der_b).unwrap();
+        assert_eq!(
+            ca.tbs_certificate.subject.as_raw(),
+            cb.tbs_certificate.subject.as_raw(),
+            "Subject DN bytes must be identical across re-sign"
+        );
+    }
+
+    #[test]
+    fn drift_resign_preserves_spki_bytes() {
+        use x509_parser::prelude::*;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        let (cert_a, _) = mgr.ensure(&[s("a.example")]).unwrap();
+        let (cert_b, _) = mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+
+        let der_a = der_of(&cert_a);
+        let der_b = der_of(&cert_b);
+        let (_, ca) = X509Certificate::from_der(&der_a).unwrap();
+        let (_, cb) = X509Certificate::from_der(&der_b).unwrap();
+        assert_eq!(
+            ca.tbs_certificate.subject_pki.raw,
+            cb.tbs_certificate.subject_pki.raw,
+            "SubjectPublicKeyInfo bytes must be identical across re-sign"
+        );
+    }
+
+    #[test]
+    fn drift_resign_preserves_subject_key_identifier() {
+        use x509_parser::prelude::*;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+        let (cert_a, _) = mgr.ensure(&[s("a.example")]).unwrap();
+        let (cert_b, _) = mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+
+        let der_a = der_of(&cert_a);
+        let der_b = der_of(&cert_b);
+        let (_, ca) = X509Certificate::from_der(&der_a).unwrap();
+        let (_, cb) = X509Certificate::from_der(&der_b).unwrap();
+
+        let ski = |c: &X509Certificate| -> Option<Vec<u8>> {
+            for ext in c.extensions() {
+                if let ParsedExtension::SubjectKeyIdentifier(s) = ext.parsed_extension() {
+                    return Some(s.0.to_vec());
+                }
+            }
+            None
+        };
+        match (ski(&ca), ski(&cb)) {
+            (Some(a), Some(b)) => assert_eq!(a, b, "SKI must be identical across re-sign"),
+            (None, None) => {}
+            (a, b) => panic!("SKI presence differs across re-sign: {a:?} vs {b:?}"),
+        }
+    }
+
+    /// Mints a player-style leaf cert signed by the given root. Mirrors what
+    /// `CertificateService::sign_player_cert` does in the real codebase.
+    fn mint_leaf_signed_by_root(root_pem: &str, root_key_pem: &str, leaf_cn: &str) -> String {
+        let root_kp = KeyPair::from_pem(root_key_pem).unwrap();
+        let root_params = CertificateParams::from_ca_cert_pem(root_pem).unwrap();
+        let root_cert = root_params.self_signed(&root_kp).unwrap();
+
+        let mut leaf_params = CertificateParams::default();
+        leaf_params.distinguished_name = {
+            let mut dn = DistinguishedName::new();
+            dn.push(rcgen::DnType::CommonName, leaf_cn);
+            dn
+        };
+        leaf_params.extended_key_usages = vec![
+            ExtendedKeyUsagePurpose::ClientAuth,
+            ExtendedKeyUsagePurpose::ServerAuth,
+        ];
+        leaf_params.not_before = OffsetDateTime::now_utc()
+            .checked_sub(Duration::days(1))
+            .unwrap();
+        leaf_params.not_after = OffsetDateTime::now_utc()
+            .checked_add(Duration::days(30))
+            .unwrap();
+
+        let leaf_kp = KeyPair::generate().unwrap();
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_kp, &root_cert, &root_kp)
+            .unwrap();
+        leaf_cert.pem()
+    }
+
+    #[test]
+    fn leaf_signed_before_drift_still_verifies_against_post_drift_root() {
+        use ring::signature;
+        use x509_parser::prelude::*;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+
+        let (root_pem_pre, key_pem) = mgr.ensure(&[s("a.example")]).unwrap();
+        let leaf_pem = mint_leaf_signed_by_root(&root_pem_pre, &key_pem, "player:alice");
+
+        let (root_pem_post, key_pem_2) =
+            mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+        assert_eq!(key_pem, key_pem_2, "key PEM must be unchanged");
+        assert_ne!(root_pem_pre, root_pem_post, "root cert must have re-signed");
+
+        let leaf_der = der_of(&leaf_pem);
+        let root_der_post = der_of(&root_pem_post);
+        let (_, leaf_x509) = X509Certificate::from_der(&leaf_der).unwrap();
+        let (_, root_x509_post) = X509Certificate::from_der(&root_der_post).unwrap();
+
+        let pubkey_bytes = root_x509_post
+            .tbs_certificate
+            .subject_pki
+            .subject_public_key
+            .data
+            .to_vec();
+        let tbs = leaf_x509.tbs_certificate.as_ref();
+        let sig = leaf_x509.signature_value.data.as_ref();
+
+        signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, &pubkey_bytes)
+            .verify(tbs, sig)
+            .expect("leaf signed by pre-drift root must verify against post-drift root pubkey");
+
+        let root_tbs = root_x509_post.tbs_certificate.as_ref();
+        let root_sig = root_x509_post.signature_value.data.as_ref();
+        signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, &pubkey_bytes)
+            .verify(root_tbs, root_sig)
+            .expect("post-drift self-sig must verify");
+
+        assert_eq!(
+            leaf_x509.tbs_certificate.issuer.as_raw(),
+            root_x509_post.tbs_certificate.subject.as_raw(),
+            "leaf issuer DN must still match new root subject DN"
+        );
+    }
+
+    #[test]
+    fn leaf_minted_after_drift_also_verifies_against_post_drift_root() {
+        use ring::signature;
+        use x509_parser::prelude::*;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let mgr = CaCertManager::new(path);
+
+        let (_root_pre, _) = mgr.ensure(&[s("a.example")]).unwrap();
+        let (root_post, key_post) =
+            mgr.ensure(&[s("a.example"), s("b.example")]).unwrap();
+
+        let leaf_pem = mint_leaf_signed_by_root(&root_post, &key_post, "player:bob");
+
+        let leaf_der = der_of(&leaf_pem);
+        let root_der = der_of(&root_post);
+        let (_, leaf_x509) = X509Certificate::from_der(&leaf_der).unwrap();
+        let (_, root_x509) = X509Certificate::from_der(&root_der).unwrap();
+        let pubkey_bytes = root_x509
+            .tbs_certificate
+            .subject_pki
+            .subject_public_key
+            .data
+            .to_vec();
+        let tbs = leaf_x509.tbs_certificate.as_ref();
+        let sig = leaf_x509.signature_value.data.as_ref();
+        signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, &pubkey_bytes)
+            .verify(tbs, sig)
+            .expect("post-drift-minted leaf must verify against post-drift root pubkey");
+    }
+}

--- a/server/server/src/runtime/mod.rs
+++ b/server/server/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+pub mod ca_cert;
 pub mod position_updater;
 pub mod state;
 pub use state::RuntimeState;
@@ -8,13 +9,7 @@ use crate::stream::quic::{QuicServerManager, WebhookReceiver};
 
 use anyhow::anyhow;
 use faccess::PathExt;
-use rcgen::{
-    CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose,
-};
-use rocket::time::{Duration, OffsetDateTime};
 use sea_orm::{ConnectOptions, Database, DatabaseConnection};
-use std::fs::File;
-use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -399,74 +394,14 @@ impl ServerRuntime {
         Ok(())
     }
 
-    /// Generate the root CA certificates for QUIC mTLS
+    /// Ensure the QUIC server's CA cert and key exist and that the cert's SAN
+    /// extension matches the configured `tls.names + tls.ips`. The key is
+    /// generated exactly once per deployment; the cert is re-signed with the
+    /// same key whenever the configured SAN set drifts. Returns
+    /// `(cert_pem, key_pem)`.
     async fn generate_ca(&self) -> Result<(String, String), anyhow::Error> {
-        let certs_path = &self.config.server.tls.certs_path;
-        let root_ca_path_str = format!("{}/ca.crt", certs_path);
-        let root_ca_key_path_str = format!("{}/ca.key", certs_path);
-
-        // If the certificates already exist, just return them
-        if Path::new(&root_ca_key_path_str).exists() {
-            return Ok((
-                std::fs::read_to_string(&root_ca_path_str)?,
-                std::fs::read_to_string(&root_ca_key_path_str)?,
-            ));
-        }
-
-        let cert_root_path = Path::new(certs_path);
-        if !cert_root_path.exists() {
-            std::fs::create_dir_all(cert_root_path).map_err(|_| {
-                anyhow!(
-                    "Could not create directory {}",
-                    cert_root_path.to_string_lossy()
-                )
-            })?;
-        }
-
-        // Create the root CA certificate
-        let root_kp = KeyPair::generate().map_err(|_| {
-            anyhow!(
-                "Unable to generate root key. Check the certs_path configuration variable to ensure the path is writable"
-            )
-        })?;
-
-        let mut distinguished_name = DistinguishedName::new();
-        distinguished_name.push(rcgen::DnType::CommonName, "Bedrock Voice Chat");
-
         let mut san_names = self.config.server.tls.names.clone();
         san_names.append(&mut self.config.server.tls.ips.clone());
-
-        let root_certificate = CertificateParams::new(san_names)
-            .map_err(|_| {
-                anyhow!(
-                    "Unable to generate root certificates. Check the certs_path configuration variable"
-                )
-            })
-            .and_then(|mut ca_params| {
-                ca_params.is_ca = IsCa::NoCa;
-                ca_params.not_before = OffsetDateTime::now_utc()
-                    .checked_sub(Duration::days(3))
-                    .unwrap();
-                ca_params.distinguished_name = distinguished_name;
-                ca_params.use_authority_key_identifier_extension = true;
-                ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
-                ca_params.extended_key_usages = vec![
-                    ExtendedKeyUsagePurpose::ClientAuth,
-                    ExtendedKeyUsagePurpose::ServerAuth,
-                ];
-                ca_params.self_signed(&root_kp).map_err(|e| anyhow!(e))
-            })?;
-
-        let cert = root_certificate.pem();
-        let key = root_kp.serialize_pem();
-
-        let mut cert_file = File::create(&root_ca_path_str)?;
-        cert_file.write_all(cert.as_bytes())?;
-        let mut key_file = File::create(&root_ca_key_path_str)?;
-        key_file.write_all(key.as_bytes())?;
-
-        info!("Generated CA certificates at {}", certs_path);
-
-        Ok((cert, key))
+        ca_cert::CaCertManager::new(&self.config.server.tls.certs_path).ensure(&san_names)
     }
 }


### PR DESCRIPTION
## Description
fixes #169 
ServerRuntime::generate_ca (server/server/src/runtime/mod.rs) writes ca.crt / ca.key to disk on first start, then early-returns on every subsequent start when ca.key exists. The configured SAN list (server.tls.names + server.tls.ips) is baked into ca.crt at first generation and never updated.

If an operator later changes those config values -- e.g. adds a new hostname or migrates to a different domain -- the cert continues to be served with the original SANs. Clients connecting via the new hostname fail TLS validation, since rustls/webpki rejects the cert for not matching the requested name.

Naively regenerating it on config change would invalidate every player cert ever issued (signed by the old private key) and break every client that has already pinned the old cert in its trust store. So the early-return was conservative -- but it left no path forward when SANs legitimately need to change.

The fix is to re-sign the cert on SAN drift, using the same keypair. This works because:

- Player cert chains are unaffected. They depend only on the issuer's private key and Subject DN -- both preserved.
- Pinned client trust stores still validate the new server leaf. rustls/webpki matches trust anchors by Subject DN + SubjectPublicKeyInfo, not by full-DER equality. Same keypair = same SPKI; same hardcoded CN=Bedrock Voice Chat Subject = same DN. AuthorityKeyIdentifier on existing player certs continues to point at the unchanged SubjectKeyIdentifier of the unchanged public key.

The load-bearing invariant: ca.key is generated exactly once and never replaced. As long as that holds, every leaf cert ever issued and every client that ever pinned the root keeps working.

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [x] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).