### PR TITLE
chore: bump bedrock-protocol-rs to 26.30.7 + re-enable Bedrock settings UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -954,7 +954,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bedrock-network"
 version = "0.0.9"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -975,8 +975,8 @@ dependencies = [
 
 [[package]]
 name = "bedrock-protocol"
-version = "26.30.6"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+version = "26.30.7"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bedrock-server"
 version = "0.0.10"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "base64 0.22.1",
  "bedrock-protocol",
@@ -2616,7 +2616,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3040,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4495,7 +4495,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5291,7 +5291,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5525,7 +5525,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6856,7 +6856,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7644,7 +7644,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7733,7 +7733,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8806,7 +8806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10167,7 +10167,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10681,7 +10681,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10838,7 +10838,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11677,7 +11677,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/client/src/components/settings/Sidebar.svelte
+++ b/client/src/components/settings/Sidebar.svelte
@@ -128,7 +128,7 @@
 
     // Temporary: hide the Minecraft Bedrock settings section for the beta store
     // hotfix. Flip to false (or remove this block) once connect ships publicly.
-    const hideBedrockSection = true;
+    const hideBedrockSection = false;
 
     let visibleItems = $derived(
         settingsItems.filter(item => {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -97,8 +97,8 @@ sea-orm = { version = "^2.0.0-rc.30", optional = true, features = [
 sea-orm-rocket = { version = "^0.6", optional = true }
 clap = { version = "^4", features = ["derive"], optional = true }
 schemars = { workspace = true, optional = true }
-bedrock-protocol = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.6", optional = true }
-bedrock-server = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.6", optional = true }
+bedrock-protocol = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.7", optional = true }
+bedrock-server = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.7", optional = true }
 
 [target."cfg(any(target_os = \"windows\"))".dependencies]
 cpal = { version = "^0.17", optional = true, features = ["asio"] }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bedrock-network"
 version = "0.0.9"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -731,8 +731,8 @@ dependencies = [
 
 [[package]]
 name = "bedrock-protocol"
-version = "26.30.6"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+version = "26.30.7"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "bedrock-server"
 version = "0.0.10"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "base64 0.22.1",
  "bedrock-protocol",
@@ -8087,7 +8087,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Re-tag with Bedrock Protocol 26.30.7 for StartGame change to deliver to Patreon/Members

## Summary

- Bumps `bedrock-protocol` / `bedrock-server` to tag **26.30.7** across both Cargo workspaces (root + `server/`).
- Flips `hideBedrockSection` to `false` in `client/src/components/settings/Sidebar.svelte` so the **Minecraft Bedrock** sidebar section (Proxy Connect / Realms Connect) is reachable again.

Unsigned, do not merge into `beta`. Changes are incorporated upstream
