### PR TITLE
feat: flagsmith refactoring for better feature flag control

### DIFF
--- a/.github/actions/get-build-number/action.yml
+++ b/.github/actions/get-build-number/action.yml
@@ -8,6 +8,27 @@ inputs:
   redis_token:
     description: 'Upstash Redis REST API token'
     required: true
+  sha:
+    description: 'Git commit SHA for this build'
+    required: false
+  branch:
+    description: 'Branch name (ref_name)'
+    required: false
+  ref:
+    description: 'Full Git ref (refs/heads/...)'
+    required: false
+  version:
+    description: 'Semantic version string'
+    required: false
+  track:
+    description: 'Release track (e.g. alpha, Beta Early Access, production)'
+    required: false
+  run_url:
+    description: 'URL of the GitHub Actions run'
+    required: false
+  token:
+    description: 'GitHub token used to push builds.json to gh-pages'
+    required: false
 
 outputs:
   build_number:
@@ -31,3 +52,67 @@ runs:
         fi
         echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
         echo "Build number: $BUILD_NUMBER"
+
+    - name: Record build in Redis
+      shell: bash
+      env:
+        BUILD_NUMBER: ${{ steps.incr.outputs.build_number }}
+        SHA: ${{ inputs.sha }}
+        BRANCH: ${{ inputs.branch }}
+        REF: ${{ inputs.ref }}
+        VERSION: ${{ inputs.version }}
+        TRACK: ${{ inputs.track }}
+        RUN_URL: ${{ inputs.run_url }}
+        REDIS_URL: ${{ inputs.redis_url }}
+        REDIS_TOKEN: ${{ inputs.redis_token }}
+      run: |
+        set -e
+        RECORD=$(node -e '
+          const { BuildLedger } = require("./.github/scripts/build-ledger");
+          process.stdout.write(JSON.stringify(BuildLedger.record(process.argv[1], {
+            sha: process.argv[2], branch: process.argv[3], ref: process.argv[4],
+            version: process.argv[5], track: process.argv[6], run: process.argv[7], ts: process.argv[8],
+          })));
+        ' "$BUILD_NUMBER" "$SHA" "$BRANCH" "$REF" "$VERSION" "$TRACK" "$RUN_URL" "$(date -u +%FT%TZ)")
+        if [ -z "$RECORD" ]; then
+          echo "::error::failed to build ledger record"; exit 1
+        fi
+        HSET_BODY=$(jq -nc --arg f "$BUILD_NUMBER" --arg v "$RECORD" '["HSET","builds",$f,$v]')
+        HTTP_STATUS=$(curl -s -o /tmp/hset_resp -w "%{http_code}" -X POST \
+          -H "Authorization: Bearer $REDIS_TOKEN" -H "Content-Type: application/json" \
+          "$REDIS_URL" -d "$HSET_BODY")
+        if [ "$HTTP_STATUS" != "200" ]; then
+          echo "::warning::ledger HSET returned $HTTP_STATUS for build $BUILD_NUMBER"
+        fi
+
+    - name: Publish builds.json to gh-pages
+      if: ${{ inputs.token != '' }}
+      shell: bash
+      env:
+        BUILD_NUMBER: ${{ steps.incr.outputs.build_number }}
+        REDIS_URL: ${{ inputs.redis_url }}
+        REDIS_TOKEN: ${{ inputs.redis_token }}
+        TOKEN: ${{ inputs.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+        REPO_URL="https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        PUSH_OK=0
+        for attempt in 1 2 3 4 5; do
+          rm -rf /tmp/ghp && git clone --depth 1 --branch gh-pages "$REPO_URL" /tmp/ghp || \
+            { git clone --depth 1 "$REPO_URL" /tmp/ghp && (cd /tmp/ghp && git checkout --orphan gh-pages && git rm -rf . >/dev/null 2>&1 || true); }
+          node .github/scripts/publish-build-ledger.js "$REDIS_URL" "$REDIS_TOKEN" /tmp/ghp/builds.json
+          ( cd /tmp/ghp
+            git add builds.json
+            git diff --cached --quiet && { echo "no change"; exit 0; }
+            git commit -m "chore: update build ledger ($BUILD_NUMBER) [skip ci]"
+            git push origin gh-pages
+          ) && { PUSH_OK=1; break; }
+          echo "push attempt $attempt failed; retrying"
+          sleep 3
+        done
+        if [ "$PUSH_OK" != "1" ]; then
+          echo "::error::failed to publish builds.json to gh-pages after 5 attempts"
+          exit 1
+        fi

--- a/.github/scripts/build-ledger.js
+++ b/.github/scripts/build-ledger.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class BuildLedger {
+  static record(buildNumber, meta) {
+    return {
+      build_number: Number(buildNumber),
+      sha: meta.sha || '',
+      branch: meta.branch || '',
+      ref: meta.ref || '',
+      version: meta.version || '',
+      track: meta.track || '',
+      run: meta.run || '',
+      ts: meta.ts || '',
+    };
+  }
+
+  static toJson(recordsByNumber) {
+    const builds = Object.values(recordsByNumber || {})
+      .map((v) => (typeof v === 'string' ? JSON.parse(v) : v))
+      .sort((a, b) => b.build_number - a.build_number);
+    return JSON.stringify({ builds }, null, 2) + '\n';
+  }
+}
+
+module.exports = { BuildLedger };

--- a/.github/scripts/build-ledger.test.js
+++ b/.github/scripts/build-ledger.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { BuildLedger } = require('./build-ledger');
+
+test('record builds a normalized entry with an integer build_number', () => {
+  const r = BuildLedger.record(1001084, {
+    sha: 'abc123', branch: 'beta', ref: 'refs/heads/beta',
+    version: '1.0.0-beta.13', track: 'alpha',
+    run: 'https://example/run/1', ts: '2026-06-17T00:00:00Z',
+  });
+  assert.strictEqual(r.build_number, 1001084);
+  assert.strictEqual(typeof r.build_number, 'number');
+  assert.strictEqual(r.track, 'alpha');
+});
+
+test('toJson sorts by build_number descending and parses HGETALL values', () => {
+  const hgetall = {
+    '1001084': JSON.stringify({ build_number: 1001084, track: 'alpha' }),
+    '1001090': JSON.stringify({ build_number: 1001090, track: 'beta' }),
+  };
+  const json = BuildLedger.toJson(hgetall);
+  const parsed = JSON.parse(json);
+  assert.strictEqual(parsed.builds[0].build_number, 1001090);
+  assert.strictEqual(parsed.builds[1].build_number, 1001084);
+});

--- a/.github/scripts/publish-build-ledger.js
+++ b/.github/scripts/publish-build-ledger.js
@@ -1,0 +1,22 @@
+'use strict';
+const fs = require('fs');
+const { BuildLedger } = require('./build-ledger');
+
+class LedgerPublisher {
+  static async run() {
+    const [redisUrl, redisToken, outPath] = process.argv.slice(2);
+    const res = await fetch(`${redisUrl}/hgetall/builds`, {
+      headers: { Authorization: `Bearer ${redisToken}` },
+    });
+    if (!res.ok) throw new Error(`HGETALL failed: ${res.status}`);
+    const body = await res.json();
+    // Upstash HGETALL returns a flat [field, value, field, value, ...] array.
+    const flat = body.result || [];
+    const map = {};
+    for (let i = 0; i < flat.length; i += 2) map[flat[i]] = flat[i + 1];
+    fs.writeFileSync(outPath, BuildLedger.toJson(map));
+    console.log(`Wrote ${Object.keys(map).length} builds to ${outPath}`);
+  }
+}
+
+LedgerPublisher.run().catch((e) => { console.error(e); process.exit(1); });

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -137,6 +137,13 @@ jobs:
         with:
           redis_url: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           redis_token: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          sha: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+          ref: ${{ github.ref }}
+          version: ${{ steps.version.outputs.version }}
+          track: ${{ github.ref == 'refs/heads/beta' && 'alpha' || github.ref == 'refs/heads/master' && 'production' || '' }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # Build server for multiple platforms (always runs - produces native library needed by mods)
   build-server:
@@ -168,7 +175,7 @@ jobs:
     with:
       build_mode: ${{ needs.changes.outputs.is_release_branch == 'true' && 'release' || needs.changes.outputs.build_mode }}
       build_number: ${{ needs.changes.outputs.build_number }}
-      play_store_track: ${{ github.ref == 'refs/heads/beta' && 'internal' || github.ref == 'refs/heads/master' && 'production' || '' }}
+      play_store_track: ${{ github.ref == 'refs/heads/beta' && 'alpha' || github.ref == 'refs/heads/master' && 'production' || '' }}
     secrets: inherit
 
   # Build iOS client
@@ -191,6 +198,7 @@ jobs:
     uses: ./.github/workflows/build-client.yml
     with:
       build_mode: ${{ needs.changes.outputs.is_release_branch == 'true' && 'release' || needs.changes.outputs.build_mode }}
+      build_number: ${{ needs.changes.outputs.build_number }}
     secrets: inherit
 
   # Build macOS client

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,6 +1,6 @@
 name: Build Android Client
 permissions:
-  contents: read
+  contents: write
 
 on:
   workflow_call:
@@ -113,6 +113,13 @@ jobs:
         with:
           redis_url: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           redis_token: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          sha: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+          ref: ${{ github.ref }}
+          version: ${{ steps.manualver.outputs.version }}
+          track: ${{ inputs.track }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply manual build number
         if: steps.dispatch-build-number.outputs.build_number != ''
@@ -350,6 +357,7 @@ jobs:
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           FLAGSMITH_KEY=${{ secrets.FLAGSMITH_KEY }}
           FLAGSMITH_SERVER=${{ secrets.FLAGSMITH_SERVER }}
+          APP_BUILD_NUMBER=${{ inputs.build_number != '' && inputs.build_number || steps.dispatch-build-number.outputs.build_number }}
           ENVEOF
 
       - name: Build Android

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: ''
         type: string
+      build_number:
+        description: 'Atomic build number from Redis'
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       build_mode:
@@ -147,6 +152,7 @@ jobs:
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           FLAGSMITH_KEY=${{ secrets.FLAGSMITH_KEY }}
           FLAGSMITH_SERVER=${{ secrets.FLAGSMITH_SERVER }}
+          APP_BUILD_NUMBER=${{ inputs.build_number }}
           ENVEOF
 
       - name: Build Windows client (debug)

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -225,6 +225,7 @@ jobs:
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           FLAGSMITH_KEY=${{ secrets.FLAGSMITH_KEY }}
           FLAGSMITH_SERVER=${{ secrets.FLAGSMITH_SERVER }}
+          APP_BUILD_NUMBER=${{ inputs.build_number }}
           ENVEOF
 
       - name: Build frontend

--- a/.github/workflows/build-macos-client.yml
+++ b/.github/workflows/build-macos-client.yml
@@ -115,6 +115,7 @@ jobs:
           POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           FLAGSMITH_KEY=${{ secrets.FLAGSMITH_KEY }}
           FLAGSMITH_SERVER=${{ secrets.FLAGSMITH_SERVER }}
+          APP_BUILD_NUMBER=${{ inputs.build_number }}
           ENVEOF
 
       - name: Build macOS client (debug)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,6 @@ jobs:
           redis_url: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           redis_token: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
-      - name: Get build number
-        id: build-number
-        uses: ./.github/actions/get-build-number
-        with:
-          redis_url: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-          redis_token: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
-
       - name: Run semantic-release
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
@@ -99,6 +92,21 @@ jobs:
             @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get build number
+        id: build-number
+        if: ${{ !inputs.dry_run }}
+        uses: ./.github/actions/get-build-number
+        with:
+          redis_url: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          redis_token: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          sha: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+          ref: ${{ github.ref }}
+          version: ${{ steps.semantic.outputs.new_release_version }}
+          track: ${{ github.ref == 'refs/heads/beta' && 'Beta Early Access' || 'production' }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release summary
         run: |
@@ -252,6 +260,7 @@ jobs:
       build_mode: release
       ref: ${{ inputs.dry_run && github.ref || needs.prepare-release.outputs.new_tag }}
       version: ${{ needs.prepare-release.outputs.new_version }}
+      build_number: ${{ needs.prepare-release.outputs.build_number }}
     secrets: inherit
 
   # Job 6: Build macOS client (release mode, signed + TestFlight upload)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bedrock-network"
 version = "0.0.9"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -975,8 +975,8 @@ dependencies = [
 
 [[package]]
 name = "bedrock-protocol"
-version = "26.30.6"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+version = "26.30.7"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bedrock-server"
 version = "0.0.10"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "base64 0.22.1",
  "bedrock-protocol",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ description = "Bedrock Voice Chat Client"
 authors = ["Charles R. Portwood II"]
 edition = "2024"
 default-run = "bedrock-voice-chat-client"
+autotests = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,6 +15,10 @@ default-run = "bedrock-voice-chat-client"
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "bvc_client_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"
 
 [build-dependencies]
 tauri-build = { version = "^2.4", features = [] }

--- a/client/src-tauri/build.rs
+++ b/client/src-tauri/build.rs
@@ -41,6 +41,11 @@ fn main() {
         println!("cargo:rustc-env=FLAGSMITH_SERVER={}", server);
     }
 
+    println!("cargo:rerun-if-env-changed=APP_BUILD_NUMBER");
+    if let Ok(build_number) = std::env::var("APP_BUILD_NUMBER") {
+        println!("cargo:rustc-env=APP_BUILD_NUMBER={}", build_number);
+    }
+
     let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 

--- a/client/src-tauri/src/bedrock/gating/mod.rs
+++ b/client/src-tauri/src/bedrock/gating/mod.rs
@@ -149,6 +149,7 @@ mod tests {
             String::new(),
             String::new(),
             String::new(),
+            0,
             std::time::Duration::from_secs(3600),
         ));
         let telemetry = Arc::new(crate::logging::Telemetry::new(false));

--- a/client/src-tauri/src/bedrock/proxy/manager.rs
+++ b/client/src-tauri/src/bedrock/proxy/manager.rs
@@ -653,6 +653,7 @@ mod tests {
             String::new(),
             String::new(),
             String::new(),
+            0,
             std::time::Duration::from_secs(3600),
         ));
         let telemetry = Arc::new(crate::logging::Telemetry::new(false));

--- a/client/src-tauri/src/commands/feature_flags.rs
+++ b/client/src-tauri/src/commands/feature_flags.rs
@@ -1,3 +1,4 @@
+use crate::feature_flags::flags::bedrock::BedrockConnectEnabled;
 use crate::feature_flags::FeatureFlagService;
 use std::sync::Arc;
 use tauri::State;
@@ -8,4 +9,11 @@ pub(crate) async fn get_feature_flag(
     service: State<'_, Arc<FeatureFlagService>>,
 ) -> Result<bool, String> {
     Ok(service.is_enabled(&flag).await)
+}
+
+#[tauri::command]
+pub(crate) async fn get_bedrock_connect_enabled(
+    service: State<'_, Arc<FeatureFlagService>>,
+) -> Result<bool, String> {
+    Ok(service.get(BedrockConnectEnabled).await)
 }

--- a/client/src-tauri/src/feature_flags/feature_flag_service.rs
+++ b/client/src-tauri/src/feature_flags/feature_flag_service.rs
@@ -14,6 +14,7 @@ pub struct FeatureFlagService {
     api_key: String,
     server_url: String,
     install_id: String,
+    build_number: i64,
     refresh_interval: Duration,
 }
 
@@ -22,6 +23,7 @@ impl FeatureFlagService {
         api_key: String,
         server_url: String,
         install_id: String,
+        build_number: i64,
         refresh_interval: Duration,
     ) -> Self {
         let (ready_tx, ready_rx) = watch::channel(false);
@@ -32,6 +34,7 @@ impl FeatureFlagService {
             api_key,
             server_url,
             install_id,
+            build_number,
             refresh_interval,
         }
     }
@@ -47,6 +50,7 @@ impl FeatureFlagService {
             self.api_key.clone(),
             self.server_url.clone(),
             self.install_id.clone(),
+            self.build_number,
             self.refresh_interval,
         );
 

--- a/client/src-tauri/src/feature_flags/flags/bedrock/connect_enabled.rs
+++ b/client/src-tauri/src/feature_flags/flags/bedrock/connect_enabled.rs
@@ -1,0 +1,18 @@
+use std::borrow::Cow;
+
+use crate::feature_flags::feature_flag::FeatureFlag;
+
+// Whether the Bedrock connect section (Proxy + Realms) is visible in the sidebar.
+pub struct BedrockConnectEnabled;
+
+impl FeatureFlag for BedrockConnectEnabled {
+    type Value = bool;
+
+    fn default(&self) -> bool {
+        false
+    }
+
+    fn key(&self) -> Cow<'static, str> {
+        Cow::Borrowed("feature.bedrock.connect-enabled")
+    }
+}

--- a/client/src-tauri/src/feature_flags/flags/bedrock/mod.rs
+++ b/client/src-tauri/src/feature_flags/flags/bedrock/mod.rs
@@ -1,0 +1,3 @@
+pub mod connect_enabled;
+
+pub use connect_enabled::BedrockConnectEnabled;

--- a/client/src-tauri/src/feature_flags/flags/mod.rs
+++ b/client/src-tauri/src/feature_flags/flags/mod.rs
@@ -1,1 +1,2 @@
+pub mod bedrock;
 pub mod minecraft;

--- a/client/src-tauri/src/feature_flags/flagsmith/mod.rs
+++ b/client/src-tauri/src/feature_flags/flagsmith/mod.rs
@@ -25,6 +25,7 @@ pub struct FlagsmithProvider {
     api_key: String,
     server_url: String,
     install_id: String,
+    build_number: i64,
     refresh_interval: Duration,
     http_client: reqwest::Client,
     cache: Arc<RwLock<HashMap<String, FlagsmithFlag>>>,
@@ -35,6 +36,7 @@ impl FlagsmithProvider {
         api_key: String,
         server_url: String,
         install_id: String,
+        build_number: i64,
         refresh_interval: Duration,
     ) -> Self {
         let normalized_url = if server_url.ends_with("/api/v1/") {
@@ -50,22 +52,36 @@ impl FlagsmithProvider {
             api_key,
             server_url: normalized_url,
             install_id,
+            build_number,
             refresh_interval,
             http_client: reqwest::Client::new(),
             cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    async fn refresh(&self) -> Result<(), anyhow::Error> {
-        let url = format!(
-            "{}identities/?identifier={}",
-            self.server_url, self.install_id
-        );
-        let response = self
-            .http_client
-            .get(&url)
-            .header("X-Environment-Key", &self.api_key)
+    pub fn build_identity_body(install_id: &str, build_number: i64) -> serde_json::Value {
+        serde_json::json!({
+            "identifier": install_id,
+            "traits": [
+                { "trait_key": "build_number", "trait_value": build_number, "transient": true }
+            ]
+        })
+    }
+
+    async fn fetch_into_cache(
+        http_client: &reqwest::Client,
+        server_url: &str,
+        api_key: &str,
+        install_id: &str,
+        build_number: i64,
+        cache: &RwLock<HashMap<String, FlagsmithFlag>>,
+    ) -> Result<usize, anyhow::Error> {
+        let url = format!("{}identities/", server_url);
+        let response = http_client
+            .post(&url)
+            .header("X-Environment-Key", api_key)
             .header("Content-Type", "application/json")
+            .json(&Self::build_identity_body(install_id, build_number))
             .send()
             .await?;
 
@@ -77,20 +93,25 @@ impl FlagsmithProvider {
         }
 
         let identity_response: FlagsmithIdentityResponse = response.json().await?;
-        let mut cache = self.cache.write().await;
-        cache.clear();
+        let mut c = cache.write().await;
+        c.clear();
         for flag in identity_response.flags {
-            info!(
-                "Flag '{}': enabled={}, value={:?}",
-                flag.feature.name, flag.enabled, flag.value
-            );
-            cache.insert(flag.feature.name.clone(), flag);
+            c.insert(flag.feature.name.clone(), flag);
         }
-        info!(
-            "Refreshed {} feature flags for identity {}",
-            cache.len(),
-            self.install_id
-        );
+        Ok(c.len())
+    }
+
+    async fn refresh(&self) -> Result<(), anyhow::Error> {
+        let count = Self::fetch_into_cache(
+            &self.http_client,
+            &self.server_url,
+            &self.api_key,
+            &self.install_id,
+            self.build_number,
+            &self.cache,
+        )
+        .await?;
+        info!("Refreshed {} feature flags for identity {}", count, self.install_id);
         Ok(())
     }
 
@@ -128,6 +149,7 @@ impl FeatureProvider for FlagsmithProvider {
         let api_key = self.api_key.clone();
         let server_url = self.server_url.clone();
         let install_id = self.install_id.clone();
+        let build_number = self.build_number;
         let refresh_interval = self.refresh_interval;
 
         tokio::spawn(async move {
@@ -135,30 +157,12 @@ impl FeatureProvider for FlagsmithProvider {
             interval.tick().await;
             loop {
                 interval.tick().await;
-                let url = format!("{}identities/?identifier={}", server_url, install_id);
-                match http_client
-                    .get(&url)
-                    .header("X-Environment-Key", &api_key)
-                    .header("Content-Type", "application/json")
-                    .send()
-                    .await
+                match Self::fetch_into_cache(
+                    &http_client, &server_url, &api_key, &install_id, build_number, &cache,
+                )
+                .await
                 {
-                    Ok(response) if response.status().is_success() => {
-                        match response.json::<FlagsmithIdentityResponse>().await {
-                            Ok(identity_response) => {
-                                let mut c = cache.write().await;
-                                c.clear();
-                                for flag in identity_response.flags {
-                                    c.insert(flag.feature.name.clone(), flag);
-                                }
-                                info!("Refreshed {} feature flags", c.len());
-                            }
-                            Err(e) => warn!("Feature flag refresh parse failed: {}", e),
-                        }
-                    }
-                    Ok(response) => {
-                        warn!("Feature flag refresh returned status {}", response.status());
-                    }
+                    Ok(count) => info!("Refreshed {} feature flags", count),
                     Err(e) => warn!("Feature flag refresh failed: {}", e),
                 }
             }

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod commands;
 mod deep_links;
 mod events;
 mod feature_flags;
+pub use feature_flags::flagsmith::FlagsmithProvider;
 #[cfg(feature = "bedrock-protocol")]
 mod iap;
 mod keyring;
@@ -237,6 +238,7 @@ pub fn run() {
             crate::commands::keybinds::start_keybind_listener,
             // Feature Flags
             crate::commands::feature_flags::get_feature_flag,
+            crate::commands::feature_flags::get_bedrock_connect_enabled,
             // Audio Library
             crate::commands::audio_library::upload_audio_file,
             crate::commands::audio_library::list_audio_files,
@@ -393,6 +395,9 @@ pub fn run() {
                         .unwrap_or("https://flagsmith.bedrockvoicechat.com")
                         .to_string(),
                     install_id.clone(),
+                    option_env!("APP_BUILD_NUMBER")
+                        .and_then(|s| s.parse::<i64>().ok())
+                        .unwrap_or(0),
                     std::time::Duration::from_secs(3600),
                 )
             );

--- a/client/src-tauri/tests/feature_flags/flagsmith.rs
+++ b/client/src-tauri/tests/feature_flags/flagsmith.rs
@@ -1,0 +1,21 @@
+use bvc_client_lib::FlagsmithProvider;
+
+#[test]
+fn identity_persists_but_build_number_trait_is_transient() {
+    let body = FlagsmithProvider::build_identity_body("install-abc", 1001084);
+
+    assert!(
+        body.get("transient").is_none() || body["transient"] == serde_json::json!(false),
+        "the install identity must persist; only the build_number trait is transient"
+    );
+
+    let traits = body["traits"].as_array().expect("traits array");
+    let build = traits
+        .iter()
+        .find(|t| t["trait_key"] == serde_json::json!("build_number"))
+        .expect("build_number trait");
+
+    assert!(build["trait_value"].is_i64(), "build_number must serialize as an integer");
+    assert_eq!(build["trait_value"], serde_json::json!(1001084));
+    assert_eq!(build["transient"], serde_json::json!(true));
+}

--- a/client/src-tauri/tests/feature_flags/mod.rs
+++ b/client/src-tauri/tests/feature_flags/mod.rs
@@ -1,0 +1,1 @@
+mod flagsmith;

--- a/client/src-tauri/tests/integration.rs
+++ b/client/src-tauri/tests/integration.rs
@@ -1,0 +1,1 @@
+mod feature_flags;

--- a/client/src/components/settings/Sidebar.svelte
+++ b/client/src/components/settings/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { mount, onMount, onDestroy } from "svelte";
+    import { invoke } from "@tauri-apps/api/core";
     import account from "../../components/settings/pages/account.svelte";
     import audio from "../../components/settings/pages/audio.svelte";
     import keybinds from "../../components/settings/pages/keybinds.svelte";
@@ -126,9 +127,8 @@
 
     const mobileHiddenPages = new Set(["recordings.svelte", "audioLibrary.svelte", "websocket.svelte", "keybinds.svelte"]);
 
-    // Temporary: hide the Minecraft Bedrock settings section for the beta store
-    // hotfix. Flip to false (or remove this block) once connect ships publicly.
-    const hideBedrockSection = true;
+    // Hidden until 'feature.bedrock.connect-enabled' resolves true.
+    let hideBedrockSection = $state(true);
 
     let visibleItems = $derived(
         settingsItems.filter(item => {
@@ -230,6 +230,13 @@
             isMobile = await platformDetector.checkMobile();
         } catch (error) {
             isMobile = false;
+        }
+
+        try {
+            const enabled = await invoke<boolean>("get_bedrock_connect_enabled");
+            hideBedrockSection = !enabled;
+        } catch (error) {
+            hideBedrockSection = true;
         }
     });
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -97,8 +97,8 @@ sea-orm = { version = "^2.0.0-rc.30", optional = true, features = [
 sea-orm-rocket = { version = "^0.6", optional = true }
 clap = { version = "^4", features = ["derive"], optional = true }
 schemars = { workspace = true, optional = true }
-bedrock-protocol = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.6", optional = true }
-bedrock-server = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.6", optional = true }
+bedrock-protocol = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.7", optional = true }
+bedrock-server = { git = "https://github.com/alaydriem/bedrock-protocol-rs", tag = "26.30.7", optional = true }
 
 [target."cfg(any(target_os = \"windows\"))".dependencies]
 cpal = { version = "^0.17", optional = true, features = ["asio"] }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -710,7 +710,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bedrock-network"
 version = "0.0.9"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -731,8 +731,8 @@ dependencies = [
 
 [[package]]
 name = "bedrock-protocol"
-version = "26.30.6"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+version = "26.30.7"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "bedrock-server"
 version = "0.0.10"
-source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.6#00ac59692b2025581d12cf0470047caf2db435b2"
+source = "git+https://github.com/alaydriem/bedrock-protocol-rs?tag=26.30.7#7d43717ce444eeb7ffba196a33decdbd56f76e7f"
 dependencies = [
  "base64 0.22.1",
  "bedrock-protocol",


### PR DESCRIPTION
## Description
- Changes the flagsmith implementation so that there is a single FLAGMSITH_KEY and feature flag management is driven by segments, traits, and build_numbers from get-build-number
- get-build-number now writes to gh-pages a dedicated build history file for historical tracking as json

### New Build Targets
| Platform | Merge  `beta` (push) | Release/tag on `beta` | Merge  `master` (push) | Release/tag on `master` | One-off dispatch |
|---|---|---|---|---|---|
| **Android** (signed AAB) | **Closed testing  `alpha`** (changed; was `internal`), status `completed` | Open testing  `Beta Early Access`, status `completed` | `production`, status `draft` | `production`, status `draft` | dispatched `track` input |
| **iOS** (signed IPA) | TestFlight | TestFlight | TestFlight | TestFlight | build only (no number, deferred) |
| **macOS** (signed pkg) | TestFlight | TestFlight | TestFlight | TestFlight | build only (deferred) |
| **Windows** (NSIS / MSIX) | CI run artifact | GitHub Release assets (incl. MSIX); Store deferred | CI run artifact | GitHub Release assets (incl. MSIX); Store deferred |  |

## Checklist
- [x] I have read the [CLA](../CLA.md)
- [x] I have discussed this pull request in a prior issue or discussion prior to submitting it, and received approval from the maintainers that it will be reviewed for acceptance
- [x] All commits are signed off (`git commit -s`)
- [x] Tests pass locally and were run
- [ ] Changes were manually validated (if needed)
- [x] Documentation updated (if needed)

---

By submitting this PR with signed commits, I certify that I agree to the project's [Contributor License Agreement](../CLA.md).